### PR TITLE
docs: translations react-dom/server: Server APIs

### DIFF
--- a/src/content/reference/react-dom/server/index.md
+++ b/src/content/reference/react-dom/server/index.md
@@ -1,5 +1,5 @@
 ---
-title: API React Dom Server
+title: API React DOM Server
 ---
 
 <Intro>
@@ -21,24 +21,24 @@ Metode-metode ini hanya tersedia di lingkungan dengan [Node.js *Stream*:](https:
 
 ## API *Server* untuk *Web Stream* {/*server-apis-for-web-streams*/}
 
-Metode-metode ini hanya tersedia di lingkungan dengan [*Web Stream*](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), yang mencakup *browser*, Deno, dan beberapa *runtime* modern:
+Beberapa *method* ini hanya tersedia di lingkungan dengan [*Web Stream*](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), yang mencakup peramban, Deno, dan beberapa *runtime* modern:
 
 * [`renderToReadableStream`](/reference/react-dom/server/renderToReadableStream) me-*render* sebuah React *tree* ke dalam [*Readable Web Stream*.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
 
 ---
 
-## API Server untuk lingkungan non*streaming* {/*server-apis-for-non-streaming-environments*/}
+## API Server untuk lingkungan non-streaming {/*server-apis-for-non-streaming-environments*/}
 
-Metode-metode ini dapat digunakan di lingkungan yang tidak mendukung *stream*:
+Beberapa *method* ini dapat digunakan di lingkungan yang tidak mendukung *stream*:
 
 * [`renderToString`](/reference/react-dom/server/renderToString) me-*render* sebuah React *tree* ke dalam *string*.
 * [`renderToStaticMarkup`](/reference/react-dom/server/renderToStaticMarkup) me-*render* sebuah React *tree* yang noninteraktif ke dalam *string*.
 
-Metode-metode tersebut memiliki fungsionalitas terbatas dibandingkan dengan API *streaming*.
+Beberapa *method* tersebut memiliki fungsionalitas terbatas dibandingkan dengan API *streaming*.
 
 ---
 
-## API *server* yang sudah tidak digunakan {/*deprecated-server-apis*/}
+## API server yang sudah tidak digunakan {/*deprecated-server-apis*/}
 
 <Deprecated>
 

--- a/src/content/reference/react-dom/server/index.md
+++ b/src/content/reference/react-dom/server/index.md
@@ -12,7 +12,7 @@ API `react-dom/server` memungkinkan Anda me-*render* komponen React menjadi HTML
 
 ## API *Server* untuk Node.js *Stream* {/*server-apis-for-nodejs-streams*/}
 
-Metode-metode ini hanya tersedia di lingkungan dengan [Node.js *Stream*:](https://nodejs.org/api/stream.html)
+Beberapa *method* ini hanya tersedia di lingkungan dengan [Node.js *Stream*:](https://nodejs.org/api/stream.html)
 
 * [`renderToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) me-*render* sebuah React *tree* ke dalam [Node.js *Stream*](https://nodejs.org/api/stream.html) yang *pipeable*.
 * [`renderToStaticNodeStream`](/reference/react-dom/server/renderToStaticNodeStream) me-*render* sebuah React *tree* noninteraktif ke dalam [Node.js *Readable Stream*.](https://nodejs.org/api/stream.html#readable-streams)

--- a/src/content/reference/react-dom/server/index.md
+++ b/src/content/reference/react-dom/server/index.md
@@ -1,49 +1,49 @@
 ---
-title: Server React DOM APIs
+title: API React Dom Server
 ---
 
 <Intro>
 
-The `react-dom/server` APIs let you render React components to HTML on the server. These APIs are only used on the server at the top level of your app to generate the initial HTML. A [framework](/learn/start-a-new-react-project#production-grade-react-frameworks) may call them for you. Most of your components don't need to import or use them.
+API `react-dom/server` memungkinkan Anda me-*render* komponen React menjadi HTML di *server*. API ini hanya digunakan di *server* pada *top level* aplikasi Anda untuk menghasilkan HTML awal. React DOM Server dapat dipanggil dengan menggunakan [*framework*](/learn/start-a-new-react-project#production-grade-react-frameworks). Sebagian besar komponen Anda tidak perlu mengimpor atau menggunakannya.
 
 </Intro>
 
 ---
 
-## Server APIs for Node.js Streams {/*server-apis-for-nodejs-streams*/}
+## API *Server* untuk Node.js *Stream* {/*server-apis-for-nodejs-streams*/}
 
-These methods are only available in the environments with [Node.js Streams:](https://nodejs.org/api/stream.html)
+Metode-metode ini hanya tersedia di lingkungan dengan [Node.js *Stream*:](https://nodejs.org/api/stream.html)
 
-* [`renderToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) renders a React tree to a pipeable [Node.js Stream.](https://nodejs.org/api/stream.html)
-* [`renderToStaticNodeStream`](/reference/react-dom/server/renderToStaticNodeStream) renders a non-interactive React tree to a [Node.js Readable Stream.](https://nodejs.org/api/stream.html#readable-streams)
-
----
-
-## Server APIs for Web Streams {/*server-apis-for-web-streams*/}
-
-These methods are only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), which includes browsers, Deno, and some modern edge runtimes:
-
-* [`renderToReadableStream`](/reference/react-dom/server/renderToReadableStream) renders a React tree to a [Readable Web Stream.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+* [`renderToPipeableStream`](/reference/react-dom/server/renderToPipeableStream) me-*render* sebuah React *tree* ke dalam [Node.js *Stream*](https://nodejs.org/api/stream.html) yang *pipeable*.
+* [`renderToStaticNodeStream`](/reference/react-dom/server/renderToStaticNodeStream) me-*render* sebuah React *tree* noninteraktif ke dalam [Node.js *Readable Stream*.](https://nodejs.org/api/stream.html#readable-streams)
 
 ---
 
-## Server APIs for non-streaming environments {/*server-apis-for-non-streaming-environments*/}
+## API *Server* untuk *Web Stream* {/*server-apis-for-web-streams*/}
 
-These methods can be used in the environments that don't support streams:
+Metode-metode ini hanya tersedia di lingkungan dengan [*Web Stream*](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API), yang mencakup *browser*, Deno, dan beberapa *runtime* modern:
 
-* [`renderToString`](/reference/react-dom/server/renderToString) renders a React tree to a string.
-* [`renderToStaticMarkup`](/reference/react-dom/server/renderToStaticMarkup) renders a non-interactive React tree to a string.
-
-They have limited functionality compared to the streaming APIs.
+* [`renderToReadableStream`](/reference/react-dom/server/renderToReadableStream) me-*render* sebuah React *tree* ke dalam [*Readable Web Stream*.](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
 
 ---
 
-## Deprecated server APIs {/*deprecated-server-apis*/}
+## API Server untuk lingkungan non*streaming* {/*server-apis-for-non-streaming-environments*/}
+
+Metode-metode ini dapat digunakan di lingkungan yang tidak mendukung *stream*:
+
+* [`renderToString`](/reference/react-dom/server/renderToString) me-*render* sebuah React *tree* ke dalam *string*.
+* [`renderToStaticMarkup`](/reference/react-dom/server/renderToStaticMarkup) me-*render* sebuah React *tree* yang noninteraktif ke dalam *string*.
+
+Metode-metode tersebut memiliki fungsionalitas terbatas dibandingkan dengan API *streaming*.
+
+---
+
+## API *server* yang sudah tidak digunakan {/*deprecated-server-apis*/}
 
 <Deprecated>
 
-These APIs will be removed in a future major version of React.
+API ini akan dihapus pada versi utama React di masa depan.
 
 </Deprecated>
 
-* [`renderToNodeStream`](/reference/react-dom/server/renderToNodeStream) renders a React tree to a [Node.js Readable stream.](https://nodejs.org/api/stream.html#readable-streams) (Deprecated.)
+* [`renderToNodeStream`](/reference/react-dom/server/renderToNodeStream) me-*render* sebuah React *tree* ke dalam [Node.js *Readable stream*.](https://nodejs.org/api/stream.html#readable-streams) (*Deprecated*.)


### PR DESCRIPTION
Translation for react-dom/server: Server APIs (en -> id)

Closes https://github.com/reactjs/id.react.dev/issues/456