### PR TITLE
docs: translate `<textarea>` reference

### DIFF
--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -4,7 +4,7 @@ title: "<textarea>"
 
 <Intro>
 
-komponen [bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) memungkinkan Anda merender teks input dengan banyak baris.
+komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda merender teks input dengan banyak baris.
 
 ```js
 <textarea />
@@ -20,7 +20,7 @@ komponen [bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/
 
 ### `<textarea>` {/*textarea*/}
 
-Untuk menampilkan sebuah area teks, render [komponen bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
+Untuk menampilkan sebuah area teks, render [komponen bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 ```js
 <textarea name="postContent" />

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -36,7 +36,7 @@ Anda dapat [membuat sebuah area teks yang terkendali (*controlled*)](#controllin
 
 * `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
-Ketika Anda memberikan `value`, Anda harus mengoper juga sebuah *handler* `onChange` yang memperbarui nilai yang dioper sebelumnya.
+Ketika Anda mengoper `value`, Anda harus mengoper juga sebuah *handler* `onChange` yang memperbarui nilai yang dioper sebelumnya.
 
 Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh mengoper `defaultValue` sebagai gantinya:
 
@@ -69,7 +69,7 @@ Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh mengoper `d
 
 #### Caveats {/*caveats*/}
 
-- Memberikan anak (*children*) seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
+- Mengoper anak (*children*) seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
 - Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali.](#controlling-a-text-area-with-a-state-variable)
 - Sebuah area teks tidak dapat menjadi terkendali dan tidak terkendali secara bersamaan.
 - Sebuah area teks tidak dapat beralih menjadi terkendali atau tidak terkendali selama masa pakainya.
@@ -177,7 +177,7 @@ label, textarea { display: block; }
 
 <Pitfall>
 
-Tidak seperti HTML, memberikan teks awal seperti `<textarea>Some content</textarea>` tidak didukung.
+Tidak seperti HTML, mengoper teks awal seperti `<textarea>Some content</textarea>` tidak didukung.
 
 </Pitfall>
 
@@ -253,7 +253,7 @@ Secara *default*, *setiap* `<button>` yang berada di dalam sebuah `<form>` akan 
 
 Sebuah area teks seperti `<textarea />` bersifat *tak terkendali.* Meskipun jika Anda [mengoper sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
 
-**Untuk me-*render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, Anda akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
+**Untuk me-*render* sebuah teks area _terkendali_, oper *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, Anda akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
 
 ```js {2,6,7}
 function NewPost() {
@@ -330,7 +330,7 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 
 <Pitfall>
 
-**Jika Anda mengoper `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang dioper. Sehingga jika Anda mengoper sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkron selama *event handler* `onChange`, React akan mengembalikan area teks kembali ke `value` yang Anda berikan sebelumnya setelah setiap penekanan tombol.
+**Jika Anda mengoper `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan mengoper suatu `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang dioper. Sehingga jika Anda mengoper sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkron selama *event handler* `onChange`, React akan mengembalikan area teks kembali ke `value` yang Anda berikan sebelumnya setelah setiap penekanan tombol.
 
 </Pitfall>
 
@@ -353,7 +353,7 @@ Anda memberikan sebuah *prop* `value` ke sebuah *field* formulir tanpa sebuah *h
 
 </ConsoleBlock>
 
-Seperti yang disarankan pada pesan *error* berikut, jika Anda hanya ingin [menentukan nilai *awal*,](#providing-an-initial-value-for-a-text-area) berikan `defaultValue` sebagai gantinya:
+Seperti yang disarankan pada pesan *error* berikut, jika Anda hanya ingin [menentukan nilai *awal*,](#providing-an-initial-value-for-a-text-area) oper `defaultValue` sebagai gantinya:
 
 ```js
 // ✅ Good: area teks tidak terkendali dengan sebuah nilai awal
@@ -418,6 +418,6 @@ Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan dit
 
 Jika Anda memberikan sebuah `value` ke komponen, nilai tersebut harus tetap berupa string selama masa pakainya.
 
-Anda tidak dapat memberikan `value={undefined}` terlebih dahulu dan kemudian memberikan `value="some string"` karena React tidak akan mengetahui apakah anda ingin komponennya menjadi tidak terkontrol atau terkontrol. Sebuah *controlled component* harus selalu menerima sebuah string `value`, bukan `null` atau `undefined`.
+Anda tidak dapat mengoper `value={undefined}` terlebih dahulu dan kemudian oper `value="some string"` karena React tidak akan mengetahui apakah anda ingin komponennya menjadi tidak terkontrol atau terkontrol. Sebuah *controlled component* harus selalu menerima sebuah string `value`, bukan `null` atau `undefined`.
 
-Jika `value` Anda berasal dari sebuah API atau sebuah variabel *state*, nilai tersebut mungkin diinisiasi ke `null` atau `undefined`. Dalam hal ini, Berikan sebuah string kosong (`''`) pada awalnya, atau berikan `value={someValue ?? ''}` untuk memastikan `value`-nya adalah string.
+Jika `value` Anda berasal dari sebuah API atau sebuah variabel *state*, nilai tersebut mungkin diinisiasi ke `null` atau `undefined`. Dalam hal ini, Berikan sebuah string kosong (`''`) pada awalnya, atau oper `value={someValue ?? ''}` untuk memastikan `value`-nya adalah string.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -36,7 +36,7 @@ Anda dapat [membuat sebuah area teks yang terkontrol](#controlling-a-text-area-w
 
 * `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
-Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` <em>handler</em> yang memperbarui nilai yang diberikan sebelumnya.
+Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` *handler* yang memperbarui nilai yang diberikan sebelumnya.
 
 Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` sebagai gantinya:
 
@@ -46,20 +46,20 @@ Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` se
 
 * [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Nilainya `'on'` atau `'off'`. Menentukan perilaku penyelesaian otomatis.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
-* `children`: `<textarea>` tidak menerima <em>children</em>. Untuk Menentukan nilai awal, gunakan `defaultValue`.
+* `children`: `<textarea>` tidak menerima *children*. Untuk Menentukan nilai awal, gunakan `defaultValue`.
 * [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah bilangan. Menentukan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
 * [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, input tidak akan menjadi interaktif dan akan terlihat redup.
 * [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya mengacu pada induk formulir terdekat.
 * [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menentukan panjang maksimum teks.
 * [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menentukan panjang minimum teks.
 * [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
-* `onChange`: Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em> . Dibutuhkan untuk [area teks terkontrol.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap tombol ditekan). Berperilaku seperti [`input` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
+* `onChange`: Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function* . Dibutuhkan untuk [area teks terkontrol.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap tombol ditekan). Berperilaku seperti [`input` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
 * `onChangeCapture`: Sebuah versi `onChange` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
-* [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em>. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
+* [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function*. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
 * `onInputCapture`: Sebuah versi `onInput` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
-* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em>. Beroperasi jika sebuah input gagal memvalidasi pada pengiriman formulir. Tidak seperti <em>event</em> bawaan `invalid`, `onInvalid` <em>event</em> pada React menggelembung.
+* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function*. Beroperasi jika sebuah input gagal memvalidasi pada pengiriman formulir. Tidak seperti *event* bawaan `invalid`, `onInvalid` *event* pada React menggelembung.
 * `onInvalidCapture`: Sebuah versi `onInvalid` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
-* [`onSelect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event): Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em>. Beroperasi setelah pemilihan di dalam `<textarea>` berubah. React memperluas `onSelect` <em>event</em> untuk juga mengaktifkan pemilihan kosong dan pengeditan (dapat mempengaruhi pemilihan).
+* [`onSelect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event): Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function*. Beroperasi setelah pemilihan di dalam `<textarea>` berubah. React memperluas `onSelect` *event* untuk juga mengaktifkan pemilihan kosong dan pengeditan (dapat mempengaruhi pemilihan).
 * `onSelectCapture`: Sebuah versi `onSelect` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`placeholder`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-placeholder): Sebuah string. Ditampilkan dalam warna redup ketika nilai area teks kosong.
 * [`readOnly`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-readonly): Sebuah boolean. Jika `true`, area teks tidak dapat diubah oleh pengguna.
@@ -69,11 +69,11 @@ Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` se
 
 #### Caveats {/*caveats*/}
 
-- Memberikan <em>children</em> seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
-- Jika menerima sebuah <em>prop</em> `value` string, sebuah area teks akan [dianggap sebagai terkontrol.](#controlling-a-text-area-with-a-state-variable)
+- Memberikan *children* seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
+- Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai terkontrol.](#controlling-a-text-area-with-a-state-variable)
 - Sebuah area teks tidak dapat menjadi terkontrol dan tidak terkontrol secara bersamaan.
 - Sebuah area teks tidak dapat beralih menjadi terkontrol atau tidak terkontrol selama masa pakainya.
-- Setiap area teks terkontrol membutuhkan sebuah `onChange` <em>event handler</em> yang mengubah nilai pendukungnya secara sinkronis.
+- Setiap area teks terkontrol membutuhkan sebuah `onChange` *event handler* yang mengubah nilai pendukungnya secara sinkronis.
 
 ---
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -44,15 +44,15 @@ Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` se
 
 `<textarea>` props ini relevan baik untuk area text terkontrol maupun terkontrol:
 
-* [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Either `'on'` or `'off'`. Specifies the autocomplete behavior.
-* [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): A boolean. If `true`, React will focus the element on mount.
-* `children`: `<textarea>` does not accept children. To set the initial value, use `defaultValue`.
-* [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): A number. Specifies the default width in average character widths. Defaults to `20`.
-* [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): A boolean. If `true`, the input will not be interactive and will appear dimmed.
-* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): A string. Specifies the `id` of the `<form>` this input belongs to. If omitted, it's the closest parent form.
-* [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): A number. Specifies the maximum length of text.
-* [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): A number. Specifies the minimum length of text.
-* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): A string. Specifies the name for this input that's [submitted with the form.](#reading-the-textarea-value-when-submitting-a-form)
+* [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Salah satu `'on'` atau `'off'`. Menetapkan perilaku pelengkapan otomatis.
+* [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
+* `children`: `<textarea>` tidak menerima children. Untuk menetapkan nilai awal, gunakan `defaultValue`.
+* [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah bilangan. Menetapkan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
+* [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, input tidak akan menjadi interaktif dan akan terlihat redup.
+* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menetapkan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya adalah induk formulir terdekat.
+* [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menetapkan panjang maksimum teks.
+* [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menetapkan panjang minimum teks.
+* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menetapkan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
 * `onChange`: An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Required for [controlled text areas.](#controlling-a-text-area-with-a-state-variable) Fires immediately when the input's value is changed by the user (for example, it fires on every keystroke). Behaves like the browser [`input` event.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
 * `onChangeCapture`: A version of `onChange` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
 * [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): An [`Event` handler](/reference/react-dom/components/common#event-handler) function. function. Fires immediately when the value is changed by the user. For historical reasons, in React it is idiomatic to use `onChange` instead which works similarly.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -4,7 +4,7 @@ title: "<textarea>"
 
 <Intro>
 
-Komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda me-*render* masukan teks dengan banyak baris (*multiline*).
+Komponen [bawaan peramban (*browser*) `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda me-*render* masukan teks dengan banyak baris (*multiline*).
 
 ```js
 <textarea />
@@ -42,7 +42,7 @@ Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh mengoper `d
 
 * `defaultValue`: Sebuah string. Menentukan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
 
-`<textarea>` *props* ini relevan baik untuk area text terkendali (*controlled*) maupun tidak terkendali (*uncontrolled*):
+`<textarea>` *props* ini relevan baik untuk area text terkendali maupun tidak terkendali:
 
 * [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Nilainya `'on'` atau `'off'`. Menentukan perilaku penyelesaian otomatis.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
@@ -53,7 +53,7 @@ Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh mengoper `d
 * [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah angka. Menentukan panjang maksimum teks.
 * [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah angka. Menentukan panjang minimum teks.
 * [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada masukan yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
-* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali (*controlled*).](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu masukan diubah oleh pengguna (misalkan, beroperasi setiap penekanan tombol). Berperilaku seperti [*event* `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
+* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu masukan diubah oleh pengguna (misalkan, beroperasi setiap penekanan tombol). Berperilaku seperti [*event* `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
 * `onChangeCapture`: Sebuah versi `onChange` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
 * `onInputCapture`: Sebuah versi `onInput` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
@@ -70,10 +70,10 @@ Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh mengoper `d
 #### Caveats {/*caveats*/}
 
 - Memberikan anak (*children*) seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
-- Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali (*controlled*).](#controlling-a-text-area-with-a-state-variable)
-- Sebuah area teks tidak dapat menjadi terkendali (*controlled*) dan tidak terkendali (*uncontrolled*) secara bersamaan.
-- Sebuah area teks tidak dapat beralih menjadi terkendali (*controlled*) atau tidak terkendali (*uncontrolled*) selama masa pakainya.
-- Setiap area teks terkendali (*controlled*) membutuhkan sebuah *event handler* `onChange` yang memperbarui nilai pendukungnya secara sinkron.
+- Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali.](#controlling-a-text-area-with-a-state-variable)
+- Sebuah area teks tidak dapat menjadi terkendali dan tidak terkendali secara bersamaan.
+- Sebuah area teks tidak dapat beralih menjadi terkendali atau tidak terkendali selama masa pakainya.
+- Setiap area teks terkendali membutuhkan sebuah *event handler* `onChange` yang memperbarui nilai pendukungnya secara sinkron.
 
 ---
 
@@ -251,7 +251,7 @@ Secara *default*, *setiap* `<button>` yang berada di dalam sebuah `<form>` akan 
 
 ### Mengendalikan sebuah area teks dengan sebuah variabel state {/*controlling-a-text-area-with-a-state-variable*/}
 
-Sebuah area teks seperti `<textarea />` bersifat *tak terkendali (uncontrolled).* Meskipun jika Anda [mengoper sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
+Sebuah area teks seperti `<textarea />` bersifat *tak terkendali.* Meskipun jika Anda [mengoper sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
 
 **Untuk me-*render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, Anda akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
 
@@ -343,7 +343,7 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 Jika Anda me-*render* sebuah area teks dengan `value` tetapi tanpa `onChange`, Anda akan melihat sebuah *error* di konsol:
 
 ```js
-// 🔴 Bug: area teks terkendali (*controlled*) tanpa handler onChange
+// 🔴 Bug: area teks terkendali tanpa handler onChange
 <textarea value={something} />
 ```
 
@@ -356,14 +356,14 @@ Anda memberikan sebuah *prop* `value` ke sebuah *field* formulir tanpa sebuah *h
 Seperti yang disarankan pada pesan *error* berikut, jika Anda hanya ingin [menentukan nilai *awal*,](#providing-an-initial-value-for-a-text-area) berikan `defaultValue` sebagai gantinya:
 
 ```js
-// ✅ Good: area teks tidak terkendali (*uncontrolled*) dengan sebuah nilai awal
+// ✅ Good: area teks tidak terkendali dengan sebuah nilai awal
 <textarea defaultValue={something} />
 ```
 
 Jika Anda ingin [mengendalikan area teks ini dengan sebuah variabel *state*,](#controlling-a-text-area-with-a-state-variable) Tentukanlah sebuah *handler* `onChange`:
 
 ```js
-// ✅ Good: area teks terkendali (*controlled*) dengan onChange
+// ✅ Good: area teks terkendali dengan onChange
 <textarea value={something} onChange={e => setSomething(e.target.value)} />
 ```
 
@@ -404,7 +404,7 @@ Untuk memperbaiki kode Anda, perbarui secara sinkron ke `e.target.value`:
 
 ```js
 function handleChange(e) {
-  // ✅ Memperbarui sebuah masukan terkendali (*controlled*) ke e.target.value secara sinkron
+  // ✅ Memperbarui sebuah masukan terkendali ke e.target.value secara sinkron
   setFirstName(e.target.value);
 }
 ```
@@ -413,7 +413,7 @@ Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan dit
 
 ---
 
-### Saya menerima sebuah error: "Sebuah komponen sedang mengubah masukan yang tidak terkendali (uncontrolled) menjadi terkendali (controlled)" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
+### Saya menerima sebuah error: "Sebuah komponen sedang mengubah masukan yang tidak terkendali menjadi terkendali" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
 
 
 Jika Anda memberikan sebuah `value` ke komponen, nilai tersebut harus tetap berupa string selama masa pakainya.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -36,7 +36,7 @@ Anda dapat [membuat sebuah area teks yang terkontrol](#controlling-a-text-area-w
 
 * `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
-Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` handler yang memperbarui nilai yang diberikan sebelumnya.
+Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` <em>handler</em> yang memperbarui nilai yang diberikan sebelumnya.
 
 Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` sebagai gantinya:
 
@@ -46,10 +46,10 @@ Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` se
 
 * [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Nilainya `'on'` atau `'off'`. Menentukan perilaku penyelesaian otomatis.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
-* `children`: `<textarea>` tidak menerima children. Untuk Menentukan nilai awal, gunakan `defaultValue`.
+* `children`: `<textarea>` tidak menerima <em>children</em>. Untuk Menentukan nilai awal, gunakan `defaultValue`.
 * [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah bilangan. Menentukan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
 * [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, input tidak akan menjadi interaktif dan akan terlihat redup.
-* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya adalah induk formulir terdekat.
+* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya mengacu pada induk formulir terdekat.
 * [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menentukan panjang maksimum teks.
 * [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menentukan panjang minimum teks.
 * [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -30,9 +30,9 @@ Untuk menampilkan sebuah area teks, *render* [komponen bawaan peramban `<textare
 
 #### Props {/*props*/}
 
-`<textarea>` mendukung semua [elemen props yang umum.](/reference/react-dom/components/common#props)
+`<textarea>` mendukung semua [elemen *props* yang umum.](/reference/react-dom/components/common#props)
 
-Anda dapat [membuat sebuah area teks yang terkendali](#controlling-a-text-area-with-a-state-variable) dengan cara memberikan sebuah prop `value`:
+Anda dapat [membuat sebuah area teks yang terkendali](#controlling-a-text-area-with-a-state-variable) dengan cara memberikan sebuah *prop* `value`:
 
 * `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
@@ -42,11 +42,11 @@ Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` se
 
 * `defaultValue`: Sebuah string. Menentukan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
 
-`<textarea>` props ini relevan baik untuk area text terkendali maupun tidak terkendali:
+`<textarea>` *props* ini relevan baik untuk area text terkendali maupun tidak terkendali:
 
 * [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Nilainya `'on'` atau `'off'`. Menentukan perilaku penyelesaian otomatis.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
-* `children`: `<textarea>` tidak menerima *children*. Untuk Menentukan nilai awal, gunakan `defaultValue`.
+* `children`: `<textarea>` tidak menerima anak (*children*). Untuk Menentukan nilai awal, gunakan `defaultValue`.
 * [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah bilangan. Menentukan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
 * [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, input tidak akan menjadi interaktif dan akan terlihat redup.
 * [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya mengacu pada induk formulir terdekat.
@@ -69,7 +69,7 @@ Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` se
 
 #### Caveats {/*caveats*/}
 
-- Memberikan *children* seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
+- Memberikan anak (*children*) seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
 - Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali.](#controlling-a-text-area-with-a-state-variable)
 - Sebuah area teks tidak dapat menjadi terkendali dan tidak terkendali secara bersamaan.
 - Sebuah area teks tidak dapat beralih menjadi terkendali atau tidak terkendali selama masa pakainya.
@@ -349,7 +349,7 @@ Jika Anda *render* sebuah area teks dengan `value` tetapi tanpa `onChange`, Anda
 
 <ConsoleBlock level="error">
 
-Anda memberikan sebuah prop `value` ke sebuah *field* formulir tanpa sebuah *handler* `onChange`. area teksnya akan ter-*render* menjadi sebuah *field* yang hanya untuk dibaca. Jika *field*-nya harus *mutable*, gunakan `defaultValue`. Selain itu, berikan `onChange` atau `readOnly`.
+Anda memberikan sebuah *prop* `value` ke sebuah *field* formulir tanpa sebuah *handler* `onChange`. area teksnya akan ter-*render* menjadi sebuah *field* yang hanya untuk dibaca. Jika *field*-nya harus *mutable*, gunakan `defaultValue`. Selain itu, berikan `onChange` atau `readOnly`.
 
 </ConsoleBlock>
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -20,7 +20,7 @@ komponen [bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/
 
 ### `<textarea>` {/*textarea*/}
 
-Untuk menampilkan sebuah text area, render [komponen bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
+Untuk menampilkan sebuah area teks, render [komponen bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 ```js
 <textarea name="postContent" />
@@ -30,19 +30,19 @@ Untuk menampilkan sebuah text area, render [komponen bawaan browser `<textarea>`
 
 #### Props {/*props*/}
 
-`<textarea>` supports all [common element props.](/reference/react-dom/components/common#props)
+`<textarea>` mendukung semua [elemen props yang umum.](/reference/react-dom/components/common#props)
 
-You can [make a text area controlled](#controlling-a-text-area-with-a-state-variable) by passing a `value` prop:
+Anda dapat [membuat sebuah area teks yang terkontrol](#controlling-a-text-area-with-a-state-variable) dengan cara memberikan sebuah prop `value`:
 
-* `value`: A string. Controls the text inside the text area.
+* `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
-When you pass `value`, you must also pass an `onChange` handler that updates the passed value.
+Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` handler yang memperbarui nilai yang diberikan sebelumnya.
 
-If your `<textarea>` is uncontrolled, you may pass the `defaultValue` prop instead:
+Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` sebagai gantinya:
 
-* `defaultValue`: A string. Specifies [the initial value](#providing-an-initial-value-for-a-text-area) for a text area.
+* `defaultValue`: Sebuah string. Menetapkan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
 
-These `<textarea>` props are relevant both for uncontrolled and controlled text areas:
+`<textarea>` props ini relevan baik untuk area text terkontrol maupun terkontrol:
 
 * [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Either `'on'` or `'off'`. Specifies the autocomplete behavior.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): A boolean. If `true`, React will focus the element on mount.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -73,13 +73,13 @@ Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` se
 - Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali.](#controlling-a-text-area-with-a-state-variable)
 - Sebuah area teks tidak dapat menjadi terkendali dan tidak terkendali secara bersamaan.
 - Sebuah area teks tidak dapat beralih menjadi terkendali atau tidak terkendali selama masa pakainya.
-- Setiap area teks terkendali membutuhkan sebuah *event handler* `onChange` yang memperbarui nilai pendukungnya secara sinkronis.
+- Setiap area teks terkendali membutuhkan sebuah *event handler* `onChange` yang memperbarui nilai pendukungnya secara sinkron.
 
 ---
 
 ## Penggunaan {/*usage*/}
 
-### Menampilkan sebua area teks {/*displaying-a-text-area*/}
+### Menampilkan sebuah area teks {/*displaying-a-text-area*/}
 
 *Render* `<textarea>` untuk menampilkan sebuah area teks. Kamu dapat menentukan ukuran bawaanya dengan atribut [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#rows) dan [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#cols), tapi secara bawaan user dapat mengubah ukurannya. Untuk menonaktifkan pengubahan ukuran, kamu dapat menentukan `resize: none` di dalam CSS.
 
@@ -111,7 +111,7 @@ label, textarea { display: block; }
 
 Umumnya, Anda akan meletakkan setiap `<textarea>` di dalam sebuah tag [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label). Ini memberitahu suatu peramban apabila label ini berkaitan dengan area teks tertentu. Ketika pengguna mengeklik label tersebut, peramban akan memfokuskan area teks. Hal ini juga diperlukan untuk aksesbilitas: sebuah layar pembaca akan memberitahu keterangan label ketika pengguna memfokuskan area teks tertentu.
 
-Jika Anda tidak dapat meletakkan `<textarea>` di dalam sebuah `<label>`, hubungkanlah mereka dengan memberikan ID yang sama kepada `<textarea id>` dan [`<label htmlFor>`.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor) untuk menghindari konflik antara *instances* pada satu komponen, buatlah sebuah ID dengan [`useId`.](/reference/react/useId)
+Jika Anda tidak dapat menyusun `<textarea>` di dalam sebuah `<label>`, hubungkanlah mereka dengan memberikan ID yang sama kepada `<textarea id>` dan [`<label htmlFor>`.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor) untuk menghindari konflik antara *instances* pada satu komponen, buatlah sebuah ID dengan [`useId`.](/reference/react/useId)
 
 <Sandpack>
 
@@ -330,94 +330,94 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 
 <Pitfall>
 
-**Jika Anda memberikan `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang diberikan. Sehingga jika Anda memberikan sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkronis selama *event handler* `onChange`, React akan mengembalikan area teks setelah setiap penekanan tombol ke `value` yang Anda berikan sebelumnya.
+**Jika Anda memberikan `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang diberikan. Sehingga jika Anda memberikan sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkron selama *event handler* `onChange`, React akan mengembalikan area teks setelah setiap penekanan tombol ke `value` yang Anda berikan sebelumnya.
 
 </Pitfall>
 
 ---
 
-## Troubleshooting {/*troubleshooting*/}
+## Penyelesain masalah {/*troubleshooting*/}
 
-### My text area doesn't update when I type into it {/*my-text-area-doesnt-update-when-i-type-into-it*/}
+### Area teks saya tidak memperbarui ketika Saya mengetiknya {/*my-text-area-doesnt-update-when-i-type-into-it*/}
 
-If you render a text area with `value` but no `onChange`, you will see an error in the console:
+Jika Anda *render* sebuah area teks dengan `value` tetapi tanpa `onChange`, Anda akan melihat sebuah *error* di konsol:
 
 ```js
-// 🔴 Bug: controlled text area with no onChange handler
+// 🔴 Bug: area teks terkendali tanpa handler onChange
 <textarea value={something} />
 ```
 
 <ConsoleBlock level="error">
 
-You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.
+Anda memberikan sebuah prop `value` ke sebuah *field* formulir tanpa sebuah *handler* `onChange`. area teksnya akan ter-*render* menjadi sebuah *field* yang hanya untuk dibaca. Jika *field*-nya harus *mutable*, gunakan `defaultValue`. Selain itu, berikan `onChange` atau `readOnly`.
 
 </ConsoleBlock>
 
-As the error message suggests, if you only wanted to [specify the *initial* value,](#providing-an-initial-value-for-a-text-area) pass `defaultValue` instead:
+Seperti yang disarankan pada pesan *error* berikut, jika Anda hanya ingin [menentukan nilai *awal*,](#providing-an-initial-value-for-a-text-area) berikan `defaultValue` sebagai gantinya:
 
 ```js
-// ✅ Good: uncontrolled text area with an initial value
+// ✅ Good: area teks tidak terkendali dengan sebuah nilai awal
 <textarea defaultValue={something} />
 ```
 
-If you want [to control this text area with a state variable,](#controlling-a-text-area-with-a-state-variable) specify an `onChange` handler:
+Jika Anda ingin [mengendalikan area teks ini dengan sebuah variabel *state*,](#controlling-a-text-area-with-a-state-variable) Tentukanlah sebuah *handler* `onChange`:
 
 ```js
-// ✅ Good: controlled text area with onChange
+// ✅ Good: area teks terkendali dengan onChange
 <textarea value={something} onChange={e => setSomething(e.target.value)} />
 ```
 
-If the value is intentionally read-only, add a `readOnly` prop to suppress the error:
+Jika nilainya sengaja diatur hanya untuk dibaca, tambahkan sebuah *prop* `readOnly` untuk menghilangkan *error*:
 
 ```js
-// ✅ Good: readonly controlled text area without on change
+// ✅ Good: area teks terkontrol yang hanya untuk dibaca tanpa onChange
 <textarea value={something} readOnly={true} />
 ```
 
 ---
 
-### My text area caret jumps to the beginning on every keystroke {/*my-text-area-caret-jumps-to-the-beginning-on-every-keystroke*/}
+### Tanda sisipan saya melompat ke awal pada setiap penekanan tombol {/*my-text-area-caret-jumps-to-the-beginning-on-every-keystroke*/}
 
-If you [control a text area,](#controlling-a-text-area-with-a-state-variable) you must update its state variable to the text area's value from the DOM during `onChange`.
+Jika Anda [mengendalikan sebuah area teks,](#controlling-a-text-area-with-a-state-variable) Anda harus memperbarui variabel *state*-nya ke nilai area teksnya melalui DOM selama `onChange`.
 
-You can't update it to something other than `e.target.value`:
+Anda tidak dapat memperbarui nilainya dengan sesuatu selain `e.target.value`:
 
 ```js
 function handleChange(e) {
-  // 🔴 Bug: updating an input to something other than e.target.value
+  // 🔴 Bug: memperbarui sebuah input dengan sesuatu selain e.target.value
   setFirstName(e.target.value.toUpperCase());
 }
 ```
 
-You also can't update it asynchronously:
+Anda juga tidak dapat memperbaruinya secara asinkron:
 
 ```js
 function handleChange(e) {
-  // 🔴 Bug: updating an input asynchronously
+  // 🔴 Bug: memperbarui sebuah input secara asinkron
   setTimeout(() => {
     setFirstName(e.target.value);
   }, 100);
 }
 ```
 
-To fix your code, update it synchronously to `e.target.value`:
+Untuk memperbaiki kode Anda, perbarui secara sinkron ke `e.target.value`:
 
 ```js
 function handleChange(e) {
-  // ✅ Updating a controlled input to e.target.value synchronously
+  // ✅ Memperbarui sebuah input terkendali ke e.target.value secara sinkron
   setFirstName(e.target.value);
 }
 ```
 
-If this doesn't fix the problem, it's possible that the text area gets removed and re-added from the DOM on every keystroke. This can happen if you're accidentally [resetting state](/learn/preserving-and-resetting-state) on every re-render. For example, this can happen if the text area or one of its parents always receives a different `key` attribute, or if you nest component definitions (which is not allowed in React and causes the "inner" component to remount on every render).
+Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan ditambahkan kembali dari DOM di setiap penekanan tombol. Ini dapat terjadi jika Anda secara tidak sengaja [menyetel ulang *state*](/learn/preserving-and-resetting-state) di setiap *render* ulang. Misalkan, ini dapat terjadi jika area teksnya atau salah satu dari *parents*-nya selalu menerima sebuah atribut `key` yang berbeda, atau jika Anda menyusun definisi komponen (dimana hal ini tidak diizinkan React dan menyebabkan komponen "dalam" terpasang ulang di setiap *render*).
 
 ---
 
-### I'm getting an error: "A component is changing an uncontrolled input to be controlled" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
+### Saya menerima sebuah error: "Sebuah komponen sedang mengubah input yang tidak terkendali menjadi terkendali" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
 
 
-If you provide a `value` to the component, it must remain a string throughout its lifetime.
+Jika Anda memberikan sebuah `value` ke komponen, nilai tersebut harus tetap berupa string selama masa pakainya.
 
-You cannot pass `value={undefined}` first and later pass `value="some string"` because React won't know whether you want the component to be uncontrolled or controlled. A controlled component should always receive a string `value`, not `null` or `undefined`.
+Anda tidak dapat memberikan `value={undefined}` terlebih dahulu dan kemudian memberikan `value="some string"` karena React tidak akan mengetahui apakah anda ingin komponennya menjadi tidak terkontrol atau terkontrol. Sebuah *controlled component* harus selalu menerima sebuah string `value`, bukan `null` atau `undefined`.
 
-If your `value` is coming from an API or a state variable, it might be initialized to `null` or `undefined`. In that case, either set it to an empty string (`''`) initially, or pass `value={someValue ?? ''}` to ensure `value` is a string.
+Jika `value` Anda berasal dari sebuah API atau sebuah variabel *state*, nilai tersebut mungkin diinisiasi ke `null` atau `undefined`. Dalam hal ini, Berikan sebuah string kosong (`''`) pada awalnya, atau berikan `value={someValue ?? ''}` untuk memastikan `value`-nya adalah string.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -16,7 +16,7 @@ komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs
 
 ---
 
-## Reference {/*reference*/}
+## Referensi {/*reference*/}
 
 ### `<textarea>` {/*textarea*/}
 
@@ -53,7 +53,7 @@ Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` se
 * [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menentukan panjang maksimum teks.
 * [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menentukan panjang minimum teks.
 * [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
-* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap tombol ditekan). Berperilaku seperti [event `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
+* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap penekanan tombol). Berperilaku seperti [event `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
 * `onChangeCapture`: Sebuah versi `onChange` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
 * `onInputCapture`: Sebuah versi `onInput` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
@@ -63,9 +63,9 @@ Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` se
 * `onSelectCapture`: Sebuah versi `onSelect` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`placeholder`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-placeholder): Sebuah string. Ditampilkan dalam warna redup ketika nilai area teks kosong.
 * [`readOnly`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-readonly): Sebuah boolean. Jika `true`, area teks tidak dapat diubah oleh pengguna.
-* [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-required): Sebuah boolean. Jika `true`, nilainya harus tersedia di formulir yang akan dikirim.
+* [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-required): Sebuah boolean. Jika `true`, nilai harus disediakan agar formulir dapat terkirim.
 * [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows): Sebuah bilangan. Menentukan tinggi bawaaan pada rata-rata tinggi karakter. Nilai bawaaan adalah `2`.
-* [`wrap`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-wrap): Nilainya `'hard'`, `'soft'`, atau `'off'`. Menentukan bagaimana suatu teks perlu dibungkus ketika mengirimkan formulir.
+* [`wrap`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-wrap): Nilainya `'hard'`, `'soft'`, atau `'off'`. Menentukan bagaimana suatu teks akan dibungkus ketika mengirimkan formulir.
 
 #### Caveats {/*caveats*/}
 
@@ -73,15 +73,15 @@ Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` se
 - Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali.](#controlling-a-text-area-with-a-state-variable)
 - Sebuah area teks tidak dapat menjadi terkendali dan tidak terkendali secara bersamaan.
 - Sebuah area teks tidak dapat beralih menjadi terkendali atau tidak terkendali selama masa pakainya.
-- Setiap area teks terkendali membutuhkan sebuah `onChange` *event handler* yang mengubah nilai pendukungnya secara sinkronis.
+- Setiap area teks terkendali membutuhkan sebuah *event handler* `onChange` yang memperbarui nilai pendukungnya secara sinkronis.
 
 ---
 
-## Usage {/*usage*/}
+## Penggunaan {/*usage*/}
 
-### Displaying a text area {/*displaying-a-text-area*/}
+### Menampilkan sebua area teks {/*displaying-a-text-area*/}
 
-Render `<textarea>` to display a text area. You can specify its default size with the [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#rows) and [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#cols) attributes, but by default the user will be able to resize it. To disable resizing, you can specify `resize: none` in the CSS.
+*Render* `<textarea>` untuk menampilkan sebuah area teks. Kamu dapat menentukan ukuran bawaanya dengan atribut [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#rows) dan [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#cols), tapi secara bawaan user dapat mengubah ukurannya. Untuk menonaktifkan pengubahan ukuran, kamu dapat menentukan `resize: none` di dalam CSS.
 
 <Sandpack>
 
@@ -89,7 +89,7 @@ Render `<textarea>` to display a text area. You can specify its default size wit
 export default function NewPost() {
   return (
     <label>
-      Write your post:
+      Tulis publikasi Anda:
       <textarea name="postContent" rows={4} cols={40} />
     </label>
   );
@@ -107,11 +107,11 @@ label, textarea { display: block; }
 
 ---
 
-### Providing a label for a text area {/*providing-a-label-for-a-text-area*/}
+### Menyediakan sebuah label untuk sebuah area teks {/*providing-a-label-for-a-text-area*/}
 
-Typically, you will place every `<textarea>` inside a [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) tag. This tells the browser that this label is associated with that text area. When the user clicks the label, the browser will focus the text area. It's also essential for accessibility: a screen reader will announce the label caption when the user focuses the text area.
+Umumnya, Anda akan meletakkan setiap `<textarea>` di dalam sebuah tag [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label). Ini memberitahu suatu peramban apabila label ini berkaitan dengan area teks tertentu. Ketika pengguna mengeklik label tersebut, peramban akan memfokuskan area teks. Hal ini juga diperlukan untuk aksesbilitas: sebuah layar pembaca akan memberitahu keterangan label ketika pengguna memfokuskan area teks tertentu.
 
-If you can't nest `<textarea>` into a `<label>`, associate them by passing the same ID to `<textarea id>` and [`<label htmlFor>`.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor) To avoid conflicts between instances of one component, generate such an ID with [`useId`.](/reference/react/useId)
+Jika Anda tidak dapat meletakkan `<textarea>` di dalam sebuah `<label>`, hubungkanlah mereka dengan memberikan ID yang sama kepada `<textarea id>` dan [`<label htmlFor>`.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor) untuk menghindari konflik antara *instances* pada satu komponen, buatlah sebuah ID dengan [`useId`.](/reference/react/useId)
 
 <Sandpack>
 
@@ -123,7 +123,7 @@ export default function Form() {
   return (
     <>
       <label htmlFor={postTextAreaId}>
-        Write your post:
+        Tulis publikasi Anda:
       </label>
       <textarea
         id={postTextAreaId}
@@ -144,9 +144,9 @@ input { margin: 5px; }
 
 ---
 
-### Providing an initial value for a text area {/*providing-an-initial-value-for-a-text-area*/}
+### Menyediakan sebuah nilai awal pada sebuah area teks {/*providing-an-initial-value-for-a-text-area*/}
 
-You can optionally specify the initial value for the text area. Pass it as the `defaultValue` string.
+Kamu dapat menentukan nilai awal pada suatu area teks secara opsional. Untuk memberikan nilai awal, gunakan `defaultValue` dengan tipe string.
 
 <Sandpack>
 
@@ -154,7 +154,7 @@ You can optionally specify the initial value for the text area. Pass it as the `
 export default function EditPost() {
   return (
     <label>
-      Edit your post:
+      Ubah publikasi anda:
       <textarea
         name="postContent"
         defaultValue="I really enjoyed biking yesterday!"
@@ -177,31 +177,31 @@ label, textarea { display: block; }
 
 <Pitfall>
 
-Unlike in HTML, passing initial text like `<textarea>Some content</textarea>` is not supported.
+Tidak seperti HTML, memberikan teks awal seperti `<textarea>Some content</textarea>` tidak didukung.
 
 </Pitfall>
 
 ---
 
-### Reading the text area value when submitting a form {/*reading-the-text-area-value-when-submitting-a-form*/}
+### Membaca nilai area teks ketika mengirimkan sebuah formulir {/*reading-the-text-area-value-when-submitting-a-form*/}
 
-Add a [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) around your textarea with a [`<button type="submit">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) inside. It will call your `<form onSubmit>` event handler. By default, the browser will send the form data to the current URL and refresh the page. You can override that behavior by calling `e.preventDefault()`. Read the form data with [`new FormData(e.target)`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
+Tambahkan sebuah [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) mengelilingi area teks Anda dengan sebuah [`<button type="submit">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) di dalamnya. Tombol itu akan memanggil `<form onSubmit>` *event handler* Anda. Secara *default*, peramban akan mengirimkan data formulir kepada URL saat ini dan memuat ulang halaman. Anda dapat mengesampingkan perilaku tersebut dengan memanggil `e.preventDefault()`. Baca data formulir dengan menggunakan [`new FormData(e.target)`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
 <Sandpack>
 
 ```js
 export default function EditPost() {
   function handleSubmit(e) {
-    // Prevent the browser from reloading the page
+    // Mencegah peramban dari memuat ulang halaman
     e.preventDefault();
 
-    // Read the form data
+    // Membaca data formulir
     const form = e.target;
     const formData = new FormData(form);
 
-    // You can pass formData as a fetch body directly:
+    // Anda dapat mengirimakn *formData* sebagai *fetch body* secara langsung:
     fetch('/some-api', { method: form.method, body: formData });
 
-    // Or you can work with it as a plain object:
+    // Atau anda dapat menggunakannya sebagai objek sederhana:
     const formJson = Object.fromEntries(formData.entries());
     console.log(formJson);
   }
@@ -212,7 +212,7 @@ export default function EditPost() {
         Post title: <input name="postTitle" defaultValue="Biking" />
       </label>
       <label>
-        Edit your post:
+        Ubah publikasi Anda:
         <textarea
           name="postContent"
           defaultValue="I really enjoyed biking yesterday!"
@@ -221,8 +221,8 @@ export default function EditPost() {
         />
       </label>
       <hr />
-      <button type="reset">Reset edits</button>
-      <button type="submit">Save post</button>
+      <button type="reset">Atur ulang suntingan</button>
+      <button type="submit">Kirim</button>
     </form>
   );
 }
@@ -237,38 +237,38 @@ input { margin: 5px; }
 
 <Note>
 
-Give a `name` to your `<textarea>`, for example `<textarea name="postContent" />`. The `name` you specified will be used as a key in the form data, for example `{ postContent: "Your post" }`.
+Berikan sebuah `name` kepada `<textarea>` Anda, misalkan `<textarea name="postContent" />`. `name` yang Anda tetapkan akan digunakan sebagai sebuah *key* di dalam data formulir, misalkan `{ postContent: "Your post" }`.
 
 </Note>
 
 <Pitfall>
 
-By default, *any* `<button>` inside a `<form>` will submit it. This can be surprising! If you have your own custom `Button` React component, consider returning [`<button type="button">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/button) instead of `<button>`. Then, to be explicit, use `<button type="submit">` for buttons that *are* supposed to submit the form.
+Secara *default*, *setiap* `<button>` yang berada di dalam sebuah `<form>` akan mengirimkan data formulir tersebut. Ini bisa mengejutkan! Jika Anda mempunyai kustom komponen React `Button` Anda sendiri, pertimbangkanlah untuk mengembalikan [`<button type="button">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/button) daripada `<button>`. Kemudian, supaya menjadi eksplisit, gunakan `<button type="submit">` untuk tombol-tombol yang seharusnya digunakan untuk mengirimkan formulir.
 
 </Pitfall>
 
 ---
 
-### Controlling a text area with a state variable {/*controlling-a-text-area-with-a-state-variable*/}
+### Mengendalikan sebuah area teks dengan sebuah variabel state {/*controlling-a-text-area-with-a-state-variable*/}
 
-A text area like `<textarea />` is *uncontrolled.* Even if you [pass an initial value](#providing-an-initial-value-for-a-text-area) like `<textarea defaultValue="Initial text" />`, your JSX only specifies the initial value, not the value right now.
+Sebuah area teks seperti `<textarea />` bersifat *tak terkendali.* Meskipun jika Anda [memberikan sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
 
-**To render a _controlled_ text area, pass the `value` prop to it.** React will force the text area to always have the `value` you passed. Typically, you will control a text area by declaring a [state variable:](/reference/react/useState)
+**Untuk *render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, kamu akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
 
 ```js {2,6,7}
 function NewPost() {
-  const [postContent, setPostContent] = useState(''); // Declare a state variable...
+  const [postContent, setPostContent] = useState(''); // Mendeklarasi sebuah variabel state...
   // ...
   return (
     <textarea
-      value={postContent} // ...force the input's value to match the state variable...
-      onChange={e => setPostContent(e.target.value)} // ... and update the state variable on any edits!
+      value={postContent} // ...memaksa nilai dari input untuk mencocokan variabel state...
+      onChange={e => setPostContent(e.target.value)} // ... dan memperbarui variabel state di setiap pengeditan!
     />
   );
 }
 ```
 
-This is useful if you want to re-render some part of the UI in response to every keystroke.
+Hal ini berguna jika Anda ingin mengulang *render* di beberapa bagian UI sebagai bentuk tanggapan di setiap penekanan tombol.
 
 <Sandpack>
 
@@ -281,7 +281,7 @@ export default function MarkdownEditor() {
   return (
     <>
       <label>
-        Enter some markdown:
+        Masukkan beberapa markdown:
         <textarea
           value={postContent}
           onChange={e => setPostContent(e.target.value)}
@@ -330,7 +330,7 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 
 <Pitfall>
 
-**If you pass `value` without `onChange`, it will be impossible to type into the text area.** When you control an text area by passing some `value` to it, you *force* it to always have the value you passed. So if you pass a state variable as a `value` but forget to update that state variable synchronously during the `onChange` event handler, React will revert the text area after every keystroke back to the `value` that you specified.
+**Jika Anda memberikan `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang diberikan. Sehingga jika Anda memberikan sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkronis selama *event handler* `onChange`, React akan mengembalikan area teks setelah setiap penekanan tombol ke `value` yang Anda berikan sebelumnya.
 
 </Pitfall>
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -4,7 +4,7 @@ title: "<textarea>"
 
 <Intro>
 
-The [built-in browser `<textarea>` component](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) lets you render a multiline text input.
+komponen [bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) memungkinkan Anda merender teks input banyak baris.
 
 ```js
 <textarea />
@@ -20,13 +20,13 @@ The [built-in browser `<textarea>` component](https://developer.mozilla.org/en-U
 
 ### `<textarea>` {/*textarea*/}
 
-To display a text area, render the [built-in browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) component.
+Untuk menampilkan sebuah text area, render [komponen bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 ```js
 <textarea name="postContent" />
 ```
 
-[See more examples below.](#usage)
+[Lihat lebih banyak contoh di bawah](#usage)
 
 #### Props {/*props*/}
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -409,7 +409,7 @@ function handleChange(e) {
 }
 ```
 
-Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan ditambahkan kembali dari DOM di setiap penekanan tombol. Ini dapat terjadi jika Anda secara tidak sengaja [menyetel ulang *state*](/learn/preserving-and-resetting-state) di setiap *render* ulang. Misalkan, ini dapat terjadi jika area teksnya atau salah satu dari *parents*-nya selalu menerima sebuah atribut `key` yang berbeda, atau jika Anda menyusun definisi komponen (dimana hal ini tidak diizinkan React dan menyebabkan komponen "dalam" terpasang ulang di setiap *render*).
+Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan ditambahkan kembali dari DOM di setiap penekanan tombol. Ini dapat terjadi jika Anda secara tidak sengaja [menyetel ulang *state*](/learn/preserving-and-resetting-state) di setiap *render* ulang. Misalkan, ini dapat terjadi jika area teksnya atau salah satu dari *parents*-nya selalu menerima sebuah atribut `key` yang berbeda, atau jika Anda menyusun definisi komponen (dimana hal ini tidak diizinkan React dan menyebabkan komponen "dalam" ter-*mount* ulang di setiap *render*).
 
 ---
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -40,32 +40,32 @@ Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` han
 
 Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` sebagai gantinya:
 
-* `defaultValue`: Sebuah string. Menetapkan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
+* `defaultValue`: Sebuah string. Menentukan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
 
 `<textarea>` props ini relevan baik untuk area text terkontrol maupun terkontrol:
 
-* [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Salah satu `'on'` atau `'off'`. Menetapkan perilaku pelengkapan otomatis.
+* [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Nilainya `'on'` atau `'off'`. Menentukan perilaku penyelesaian otomatis.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
-* `children`: `<textarea>` tidak menerima children. Untuk menetapkan nilai awal, gunakan `defaultValue`.
-* [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah bilangan. Menetapkan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
+* `children`: `<textarea>` tidak menerima children. Untuk Menentukan nilai awal, gunakan `defaultValue`.
+* [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah bilangan. Menentukan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
 * [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, input tidak akan menjadi interaktif dan akan terlihat redup.
-* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menetapkan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya adalah induk formulir terdekat.
-* [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menetapkan panjang maksimum teks.
-* [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menetapkan panjang minimum teks.
-* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menetapkan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
-* `onChange`: An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Required for [controlled text areas.](#controlling-a-text-area-with-a-state-variable) Fires immediately when the input's value is changed by the user (for example, it fires on every keystroke). Behaves like the browser [`input` event.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
-* `onChangeCapture`: A version of `onChange` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
-* [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): An [`Event` handler](/reference/react-dom/components/common#event-handler) function. function. Fires immediately when the value is changed by the user. For historical reasons, in React it is idiomatic to use `onChange` instead which works similarly.
-* `onInputCapture`: A version of `onInput` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
-* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires if an input fails validation on form submit. Unlike the built-in `invalid` event, the React `onInvalid` event bubbles.
-* `onInvalidCapture`: A version of `onInvalid` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
-* [`onSelect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event): An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires after the selection inside the `<textarea>` changes. React extends the `onSelect` event to also fire for empty selection and on edits (which may affect the selection).
-* `onSelectCapture`: A version of `onSelect` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
-* [`placeholder`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-placeholder): A string. Displayed in a dimmed color when the text area value is empty.
-* [`readOnly`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-readonly): A boolean. If `true`, the text area is not editable by the user.
-* [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-required): A boolean. If `true`, the value must be provided for the form to submit.
-* [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows): A number. Specifies the default height in average character heights. Defaults to `2`.
-* [`wrap`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-wrap): Either `'hard'`, `'soft'`, or `'off'`. Specifies how the text should be wrapped when submitting a form.
+* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya adalah induk formulir terdekat.
+* [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menentukan panjang maksimum teks.
+* [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menentukan panjang minimum teks.
+* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
+* `onChange`: Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em> . Dibutuhkan untuk [area teks terkontrol.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap tombol ditekan). Berperilaku seperti [`input` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
+* `onChangeCapture`: Sebuah versi `onChange` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
+* [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em>. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
+* `onInputCapture`: Sebuah versi `onInput` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
+* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em>. Beroperasi jika sebuah input gagal memvalidasi pada pengiriman formulir. Tidak seperti <em>event</em> bawaan `invalid`, `onInvalid` <em>event</em> pada React menggelembung.
+* `onInvalidCapture`: Sebuah versi `onInvalid` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
+* [`onSelect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event): Sebuah <em>[`Event` handler](/reference/react-dom/components/common#event-handler) function</em>. Beroperasi setelah pemilihan di dalam `<textarea>` berubah. React memperluas `onSelect` <em>event</em> untuk juga mengaktifkan pemilihan kosong dan pengeditan (dapat mempengaruhi pemilihan).
+* `onSelectCapture`: Sebuah versi `onSelect` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
+* [`placeholder`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-placeholder): Sebuah string. Ditampilkan dalam warna redup ketika nilai area teks kosong.
+* [`readOnly`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-readonly): Sebuah boolean. Jika `true`, area teks tidak dapat diubah oleh pengguna.
+* [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-required): Sebuah boolean. Jika `true`, nilainya harus tersedia di formulir yang akan dikirim.
+* [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows): Sebuah bilangan. Menentukan tinggi bawaaan pada rata-rata tinggi karakter. Nilai bawaaan adalah `2`.
+* [`wrap`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-wrap): Nilainya `'hard'`, `'soft'`, atau `'off'`. Menentukan bagaimana suatu teks perlu dibungkus ketika mengirimkan formulir.
 
 #### Caveats {/*caveats*/}
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -4,7 +4,7 @@ title: "<textarea>"
 
 <Intro>
 
-Komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda me-*render* teks input dengan banyak baris.
+Komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda me-*render* masukan teks dengan banyak baris (*multiline*).
 
 ```js
 <textarea />
@@ -48,16 +48,16 @@ Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh memberikan 
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
 * `children`: `<textarea>` tidak menerima anak (*children*). Untuk menentukan nilai awal, gunakan `defaultValue`.
 * [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah angka. Menentukan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
-* [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, input tidak akan menjadi interaktif dan akan terlihat redup.
-* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya mengacu pada induk formulir terdekat.
+* [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, masukan tidak akan menjadi interaktif dan akan terlihat redup.
+* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki masukan tersebut. Jika dihilangkan, nilainya mengacu pada induk formulir terdekat.
 * [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah angka. Menentukan panjang maksimum teks.
 * [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah angka. Menentukan panjang minimum teks.
-* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
-* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali (*controlled*).](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap penekanan tombol). Berperilaku seperti [event `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
+* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada masukan yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
+* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali (*controlled*).](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu masukan diubah oleh pengguna (misalkan, beroperasi setiap penekanan tombol). Berperilaku seperti [*event* `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
 * `onChangeCapture`: Sebuah versi `onChange` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
 * `onInputCapture`: Sebuah versi `onInput` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
-* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi jika sebuah input gagal memvalidasi pada pengiriman formulir. Tidak seperti *event* bawaan `invalid`, `onInvalid` *event* pada React menggelembung.
+* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi jika sebuah masukan gagal memvalidasi pada pengiriman formulir. Tidak seperti *event* bawaan `invalid`, `onInvalid` *event* pada React menggelembung.
 * `onInvalidCapture`: Sebuah versi `onInvalid` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`onSelect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi setelah pemilihan di dalam `<textarea>` berubah. React memperluas `onSelect` *event* untuk juga mengaktifkan pemilihan kosong dan pengeditan (dapat mempengaruhi pemilihan).
 * `onSelectCapture`: Sebuah versi `onSelect` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
@@ -261,7 +261,7 @@ function NewPost() {
   // ...
   return (
     <textarea
-      value={postContent} // ...memaksa nilai dari input untuk mencocokan variabel state...
+      value={postContent} // ...memaksa nilai dari masukan untuk mencocokan variabel state...
       onChange={e => setPostContent(e.target.value)} // ... dan memperbarui variabel state di setiap pengeditan!
     />
   );
@@ -384,7 +384,7 @@ Anda tidak dapat memperbarui nilainya dengan sesuatu selain `e.target.value`:
 
 ```js
 function handleChange(e) {
-  // 🔴 Bug: memperbarui sebuah input dengan sesuatu selain e.target.value
+  // 🔴 Bug: memperbarui sebuah masukan dengan sesuatu selain e.target.value
   setFirstName(e.target.value.toUpperCase());
 }
 ```
@@ -393,7 +393,7 @@ Anda juga tidak dapat memperbaruinya secara asinkron:
 
 ```js
 function handleChange(e) {
-  // 🔴 Bug: memperbarui sebuah input secara asinkron
+  // 🔴 Bug: memperbarui sebuah masukan secara asinkron
   setTimeout(() => {
     setFirstName(e.target.value);
   }, 100);
@@ -404,7 +404,7 @@ Untuk memperbaiki kode Anda, perbarui secara sinkron ke `e.target.value`:
 
 ```js
 function handleChange(e) {
-  // ✅ Memperbarui sebuah input terkendali (*controlled*) ke e.target.value secara sinkron
+  // ✅ Memperbarui sebuah masukan terkendali (*controlled*) ke e.target.value secara sinkron
   setFirstName(e.target.value);
 }
 ```
@@ -413,7 +413,7 @@ Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan dit
 
 ---
 
-### Saya menerima sebuah error: "Sebuah komponen sedang mengubah input yang tidak terkendali (*uncontrolled*) menjadi terkendali (*controlled*)" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
+### Saya menerima sebuah error: "Sebuah komponen sedang mengubah masukan yang tidak terkendali (*uncontrolled*) menjadi terkendali (*controlled*)" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
 
 
 Jika Anda memberikan sebuah `value` ke komponen, nilai tersebut harus tetap berupa string selama masa pakainya.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -36,9 +36,9 @@ Anda dapat [membuat sebuah area teks yang terkendali (*controlled*)](#controllin
 
 * `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
-Ketika Anda memberikan `value`, Anda harus memberikan juga sebuah *handler* `onChange` yang memperbarui nilai yang diberikan sebelumnya.
+Ketika Anda memberikan `value`, Anda harus mengoper juga sebuah *handler* `onChange` yang memperbarui nilai yang dioper sebelumnya.
 
-Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh memberikan `defaultValue` sebagai gantinya:
+Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh mengoper `defaultValue` sebagai gantinya:
 
 * `defaultValue`: Sebuah string. Menentukan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
 
@@ -111,7 +111,7 @@ label, textarea { display: block; }
 
 Umumnya, Anda akan meletakkan setiap `<textarea>` di dalam sebuah tag [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label). Ini memberitahu suatu peramban apabila label ini berkaitan dengan area teks tertentu. Ketika pengguna mengeklik label tersebut, peramban akan memfokuskan area teks. Hal ini juga diperlukan untuk aksesbilitas: sebuah layar pembaca akan memberitahu keterangan label ketika pengguna memfokuskan area teks tertentu.
 
-Jika Anda tidak dapat menyusun `<textarea>` di dalam sebuah `<label>`, hubungkanlah mereka dengan memberikan ID yang sama kepada `<textarea id>` dan [`<label htmlFor>`.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor) untuk menghindari konflik antara *instances* pada satu komponen, buatlah sebuah ID dengan [`useId`.](/reference/react/useId)
+Jika Anda tidak dapat menyusun `<textarea>` di dalam sebuah `<label>`, hubungkanlah mereka dengan mengoper ID yang sama kepada `<textarea id>` dan [`<label htmlFor>`.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor) untuk menghindari konflik antara *instances* pada satu komponen, buatlah sebuah ID dengan [`useId`.](/reference/react/useId)
 
 <Sandpack>
 
@@ -146,7 +146,7 @@ input { margin: 5px; }
 
 ### Menyediakan sebuah nilai awal pada sebuah area teks {/*providing-an-initial-value-for-a-text-area*/}
 
-Kamu dapat menentukan nilai awal pada suatu area teks secara opsional. Untuk memberikan nilai awal, gunakan `defaultValue` dengan tipe string.
+Kamu dapat menentukan nilai awal pada suatu area teks secara opsional. Untuk mengoper nilai awal, gunakan `defaultValue` dengan tipe string.
 
 <Sandpack>
 
@@ -198,7 +198,7 @@ export default function EditPost() {
     const form = e.target;
     const formData = new FormData(form);
 
-    // Anda dapat mengirimakn *formData* sebagai *fetch body* secara langsung:
+    // Anda dapat mengoper *formData* sebagai *fetch body* secara langsung:
     fetch('/some-api', { method: form.method, body: formData });
 
     // Atau anda dapat menggunakannya sebagai objek sederhana:
@@ -251,7 +251,7 @@ Secara *default*, *setiap* `<button>` yang berada di dalam sebuah `<form>` akan 
 
 ### Mengendalikan sebuah area teks dengan sebuah variabel state {/*controlling-a-text-area-with-a-state-variable*/}
 
-Sebuah area teks seperti `<textarea />` bersifat *tak terkendali (uncontrolled).* Meskipun jika Anda [memberikan sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
+Sebuah area teks seperti `<textarea />` bersifat *tak terkendali (uncontrolled).* Meskipun jika Anda [mengoper sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
 
 **Untuk me-*render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, kamu akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
 
@@ -330,7 +330,7 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 
 <Pitfall>
 
-**Jika Anda memberikan `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang diberikan. Sehingga jika Anda memberikan sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkron selama *event handler* `onChange`, React akan mengembalikan area teks kembali ke `value` yang Anda berikan sebelumnya setelah setiap penekanan tombol.
+**Jika Anda mengoper `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang dioper. Sehingga jika Anda mengoper sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkron selama *event handler* `onChange`, React akan mengembalikan area teks kembali ke `value` yang Anda berikan sebelumnya setelah setiap penekanan tombol.
 
 </Pitfall>
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -4,7 +4,7 @@ title: "<textarea>"
 
 <Intro>
 
-komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda merender teks input dengan banyak baris.
+komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda *render* teks input dengan banyak baris.
 
 ```js
 <textarea />
@@ -20,7 +20,7 @@ komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs
 
 ### `<textarea>` {/*textarea*/}
 
-Untuk menampilkan sebuah area teks, render [komponen bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
+Untuk menampilkan sebuah area teks, *render* [komponen bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 ```js
 <textarea name="postContent" />
@@ -32,17 +32,17 @@ Untuk menampilkan sebuah area teks, render [komponen bawaan peramban `<textarea>
 
 `<textarea>` mendukung semua [elemen props yang umum.](/reference/react-dom/components/common#props)
 
-Anda dapat [membuat sebuah area teks yang terkontrol](#controlling-a-text-area-with-a-state-variable) dengan cara memberikan sebuah prop `value`:
+Anda dapat [membuat sebuah area teks yang terkendali](#controlling-a-text-area-with-a-state-variable) dengan cara memberikan sebuah prop `value`:
 
 * `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
 Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` *handler* yang memperbarui nilai yang diberikan sebelumnya.
 
-Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` sebagai gantinya:
+Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` sebagai gantinya:
 
 * `defaultValue`: Sebuah string. Menentukan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
 
-`<textarea>` props ini relevan baik untuk area text terkontrol maupun terkontrol:
+`<textarea>` props ini relevan baik untuk area text terkendali maupun tidak terkendali:
 
 * [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Nilainya `'on'` atau `'off'`. Menentukan perilaku penyelesaian otomatis.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
@@ -53,13 +53,13 @@ Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` se
 * [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menentukan panjang maksimum teks.
 * [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menentukan panjang minimum teks.
 * [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
-* `onChange`: Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function* . Dibutuhkan untuk [area teks terkontrol.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap tombol ditekan). Berperilaku seperti [`input` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
+* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap tombol ditekan). Berperilaku seperti [event `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
 * `onChangeCapture`: Sebuah versi `onChange` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
-* [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function*. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
+* [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
 * `onInputCapture`: Sebuah versi `onInput` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
-* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function*. Beroperasi jika sebuah input gagal memvalidasi pada pengiriman formulir. Tidak seperti *event* bawaan `invalid`, `onInvalid` *event* pada React menggelembung.
+* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi jika sebuah input gagal memvalidasi pada pengiriman formulir. Tidak seperti *event* bawaan `invalid`, `onInvalid` *event* pada React menggelembung.
 * `onInvalidCapture`: Sebuah versi `onInvalid` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
-* [`onSelect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event): Sebuah *[`Event` handler](/reference/react-dom/components/common#event-handler) function*. Beroperasi setelah pemilihan di dalam `<textarea>` berubah. React memperluas `onSelect` *event* untuk juga mengaktifkan pemilihan kosong dan pengeditan (dapat mempengaruhi pemilihan).
+* [`onSelect`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi setelah pemilihan di dalam `<textarea>` berubah. React memperluas `onSelect` *event* untuk juga mengaktifkan pemilihan kosong dan pengeditan (dapat mempengaruhi pemilihan).
 * `onSelectCapture`: Sebuah versi `onSelect` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`placeholder`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-placeholder): Sebuah string. Ditampilkan dalam warna redup ketika nilai area teks kosong.
 * [`readOnly`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-readonly): Sebuah boolean. Jika `true`, area teks tidak dapat diubah oleh pengguna.
@@ -70,10 +70,10 @@ Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` se
 #### Caveats {/*caveats*/}
 
 - Memberikan *children* seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
-- Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai terkontrol.](#controlling-a-text-area-with-a-state-variable)
-- Sebuah area teks tidak dapat menjadi terkontrol dan tidak terkontrol secara bersamaan.
-- Sebuah area teks tidak dapat beralih menjadi terkontrol atau tidak terkontrol selama masa pakainya.
-- Setiap area teks terkontrol membutuhkan sebuah `onChange` *event handler* yang mengubah nilai pendukungnya secara sinkronis.
+- Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali.](#controlling-a-text-area-with-a-state-variable)
+- Sebuah area teks tidak dapat menjadi terkendali dan tidak terkendali secara bersamaan.
+- Sebuah area teks tidak dapat beralih menjadi terkendali atau tidak terkendali selama masa pakainya.
+- Setiap area teks terkendali membutuhkan sebuah `onChange` *event handler* yang mengubah nilai pendukungnya secara sinkronis.
 
 ---
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -330,7 +330,7 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 
 <Pitfall>
 
-**Jika Anda memberikan `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang diberikan. Sehingga jika Anda memberikan sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkron selama *event handler* `onChange`, React akan mengembalikan area teks setelah setiap penekanan tombol ke `value` yang Anda berikan sebelumnya.
+**Jika Anda memberikan `value` tanpa `onChange`, mengetik di area teks tersebut akan menjadi mustahil.** Jika Anda mengontrol sebuah area teks dengan memberikan beberapa `value` kepadanya, Anda *memaksa* area teks tersebut untuk selalu mempunyai nilai yang diberikan. Sehingga jika Anda memberikan sebuah variabel *state* sebagai sebuah `value` tetapi lupa untuk memperbarui variabel *state* tersebut secara sinkron selama *event handler* `onChange`, React akan mengembalikan area teks kembali ke `value` yang Anda berikan sebelumnya setelah setiap penekanan tombol.
 
 </Pitfall>
 

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -413,7 +413,7 @@ Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan dit
 
 ---
 
-### Saya menerima sebuah error: "Sebuah komponen sedang mengubah masukan yang tidak terkendali (*uncontrolled*) menjadi terkendali (*controlled*)" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
+### Saya menerima sebuah error: "Sebuah komponen sedang mengubah masukan yang tidak terkendali (uncontrolled) menjadi terkendali (controlled)" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
 
 
 Jika Anda memberikan sebuah `value` ke komponen, nilai tersebut harus tetap berupa string selama masa pakainya.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -81,7 +81,7 @@ Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh mengoper `d
 
 ### Menampilkan sebuah area teks {/*displaying-a-text-area*/}
 
-*Render* `<textarea>` untuk menampilkan sebuah area teks. Kamu dapat menentukan ukuran bawaanya dengan atribut [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#rows) dan [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#cols), tapi secara bawaan user dapat mengubah ukurannya. Untuk menonaktifkan pengubahan ukuran, kamu dapat menentukan `resize: none` di dalam CSS.
+*Render* `<textarea>` untuk menampilkan sebuah area teks. Anda dapat menentukan ukuran bawaanya dengan atribut [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#rows) dan [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#cols), tapi secara bawaan user dapat mengubah ukurannya. Untuk menonaktifkan pengubahan ukuran, Anda dapat menentukan `resize: none` di dalam CSS.
 
 <Sandpack>
 
@@ -146,7 +146,7 @@ input { margin: 5px; }
 
 ### Menyediakan sebuah nilai awal pada sebuah area teks {/*providing-an-initial-value-for-a-text-area*/}
 
-Kamu dapat menentukan nilai awal pada suatu area teks secara opsional. Untuk mengoper nilai awal, gunakan `defaultValue` dengan tipe string.
+Anda dapat menentukan nilai awal pada suatu area teks secara opsional. Untuk mengoper nilai awal, gunakan `defaultValue` dengan tipe string.
 
 <Sandpack>
 
@@ -253,7 +253,7 @@ Secara *default*, *setiap* `<button>` yang berada di dalam sebuah `<form>` akan 
 
 Sebuah area teks seperti `<textarea />` bersifat *tak terkendali (uncontrolled).* Meskipun jika Anda [mengoper sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
 
-**Untuk me-*render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, kamu akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
+**Untuk me-*render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, Anda akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
 
 ```js {2,6,7}
 function NewPost() {

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -4,7 +4,7 @@ title: "<textarea>"
 
 <Intro>
 
-komponen [bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) memungkinkan Anda merender teks input banyak baris.
+komponen [bawaan browser `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) memungkinkan Anda merender teks input dengan banyak baris.
 
 ```js
 <textarea />

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -4,7 +4,7 @@ title: "<textarea>"
 
 <Intro>
 
-komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda *render* teks input dengan banyak baris.
+Komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) yang memungkinkan Anda me-*render* teks input dengan banyak baris.
 
 ```js
 <textarea />
@@ -20,7 +20,7 @@ komponen [bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs
 
 ### `<textarea>` {/*textarea*/}
 
-Untuk menampilkan sebuah area teks, *render* [komponen bawaan peramban `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
+Untuk menampilkan sebuah area teks, me-*render* [komponen peramban bawaan `<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 ```js
 <textarea name="postContent" />
@@ -32,28 +32,28 @@ Untuk menampilkan sebuah area teks, *render* [komponen bawaan peramban `<textare
 
 `<textarea>` mendukung semua [elemen *props* yang umum.](/reference/react-dom/components/common#props)
 
-Anda dapat [membuat sebuah area teks yang terkendali](#controlling-a-text-area-with-a-state-variable) dengan cara memberikan sebuah *prop* `value`:
+Anda dapat [membuat sebuah area teks yang terkendali (*controlled*)](#controlling-a-text-area-with-a-state-variable) dengan cara mengoper sebuah *prop* `value`:
 
 * `value`: Sebuah string. Mengontrol teks di dalam area teks.
 
-Ketika Anda memberikan `value`, Kamu harus memberikan juga sebuah `onChange` *handler* yang memperbarui nilai yang diberikan sebelumnya.
+Ketika Anda memberikan `value`, Anda harus memberikan juga sebuah *handler* `onChange` yang memperbarui nilai yang diberikan sebelumnya.
 
-Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` sebagai gantinya:
+Jika `<textarea>` Anda tidak terkendali (*uncontrolled*), Anda boleh memberikan `defaultValue` sebagai gantinya:
 
 * `defaultValue`: Sebuah string. Menentukan [nilai awal](#providing-an-initial-value-for-a-text-area) untuk sebuah area teks.
 
-`<textarea>` *props* ini relevan baik untuk area text terkendali maupun tidak terkendali:
+`<textarea>` *props* ini relevan baik untuk area text terkendali (*controlled*) maupun tidak terkendali (*uncontrolled*):
 
 * [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocomplete): Nilainya `'on'` atau `'off'`. Menentukan perilaku penyelesaian otomatis.
 * [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autofocus): Sebuah boolean. Jika `true`, React akan memfokuskan elemen ketika terpasang.
-* `children`: `<textarea>` tidak menerima anak (*children*). Untuk Menentukan nilai awal, gunakan `defaultValue`.
-* [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah bilangan. Menentukan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
+* `children`: `<textarea>` tidak menerima anak (*children*). Untuk menentukan nilai awal, gunakan `defaultValue`.
+* [`cols`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-cols): Sebuah angka. Menentukan lebar bawaaan pada rata-rata lebar karakter. Nilai bawaan adalah `20`.
 * [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-disabled): Sebuah boolean. Jika `true`, input tidak akan menjadi interaktif dan akan terlihat redup.
 * [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-form): Sebuah string. Menentukan `id` pada suatu `<form>` yang memiliki input tersebut. Jika dihilangkan, nilainya mengacu pada induk formulir terdekat.
-* [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah bilangan. Menentukan panjang maksimum teks.
-* [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah bilangan. Menentukan panjang minimum teks.
+* [`maxLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength): Sebuah angka. Menentukan panjang maksimum teks.
+* [`minLength`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength): Sebuah angka. Menentukan panjang minimum teks.
 * [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name): Sebuah string. Menentukan nama pada input yang [dikirim dengan formulir tertentu.](#reading-the-textarea-value-when-submitting-a-form)
-* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali.](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap penekanan tombol). Berperilaku seperti [event `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
+* `onChange`: Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)* . Dibutuhkan untuk [area teks terkendali (*controlled*).](#controlling-a-text-area-with-a-state-variable) Beroperasi secara langsung ketika nilai suatu input diubah oleh pengguna (misalkan, beroperasi setiap penekanan tombol). Berperilaku seperti [event `input`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) pada peramban.
 * `onChangeCapture`: Sebuah versi `onChange` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
 * [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): Sebuah fungsi *[`Event` handler](/reference/react-dom/components/common#event-handler)*. Beroperasi secara langsung ketika suatu nilai diubah oleh pengguna. Untuk alasan historis, dalam React penggunaan `onChange` menjadi idiomatik yang berfungsi dengan cara yang serupa.
 * `onInputCapture`: Sebuah versi `onInput` yang beroperasi pada [fase penangkapan.](/learn/responding-to-events#capture-phase-events)
@@ -64,16 +64,16 @@ Jika `<textarea>` Anda tidak terkendali, Anda boleh memberikan `defaultValue` se
 * [`placeholder`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-placeholder): Sebuah string. Ditampilkan dalam warna redup ketika nilai area teks kosong.
 * [`readOnly`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-readonly): Sebuah boolean. Jika `true`, area teks tidak dapat diubah oleh pengguna.
 * [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-required): Sebuah boolean. Jika `true`, nilai harus disediakan agar formulir dapat terkirim.
-* [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows): Sebuah bilangan. Menentukan tinggi bawaaan pada rata-rata tinggi karakter. Nilai bawaaan adalah `2`.
+* [`rows`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows): Sebuah angka. Menentukan tinggi bawaaan pada rata-rata tinggi karakter. Nilai bawaaan adalah `2`.
 * [`wrap`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-wrap): Nilainya `'hard'`, `'soft'`, atau `'off'`. Menentukan bagaimana suatu teks akan dibungkus ketika mengirimkan formulir.
 
 #### Caveats {/*caveats*/}
 
 - Memberikan anak (*children*) seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
-- Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali.](#controlling-a-text-area-with-a-state-variable)
-- Sebuah area teks tidak dapat menjadi terkendali dan tidak terkendali secara bersamaan.
-- Sebuah area teks tidak dapat beralih menjadi terkendali atau tidak terkendali selama masa pakainya.
-- Setiap area teks terkendali membutuhkan sebuah *event handler* `onChange` yang memperbarui nilai pendukungnya secara sinkron.
+- Jika menerima sebuah *prop* `value` string, sebuah area teks akan [dianggap sebagai komponen terkendali (*controlled*).](#controlling-a-text-area-with-a-state-variable)
+- Sebuah area teks tidak dapat menjadi terkendali (*controlled*) dan tidak terkendali (*uncontrolled*) secara bersamaan.
+- Sebuah area teks tidak dapat beralih menjadi terkendali (*controlled*) atau tidak terkendali (*uncontrolled*) selama masa pakainya.
+- Setiap area teks terkendali (*controlled*) membutuhkan sebuah *event handler* `onChange` yang memperbarui nilai pendukungnya secara sinkron.
 
 ---
 
@@ -251,9 +251,9 @@ Secara *default*, *setiap* `<button>` yang berada di dalam sebuah `<form>` akan 
 
 ### Mengendalikan sebuah area teks dengan sebuah variabel state {/*controlling-a-text-area-with-a-state-variable*/}
 
-Sebuah area teks seperti `<textarea />` bersifat *tak terkendali.* Meskipun jika Anda [memberikan sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
+Sebuah area teks seperti `<textarea />` bersifat *tak terkendali (uncontrolled).* Meskipun jika Anda [memberikan sebuah nilai awal](#providing-an-initial-value-for-a-text-area) seperti `<textarea defaultValue="Initial text" />`, JSX Anda hanya menetapkan nilai awal, bukan nilai saat ini.
 
-**Untuk *render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, kamu akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
+**Untuk me-*render* sebuah teks area _terkendali_, berikan *prop* `value` kepada area teksnya.** React akan memaksa area teks tersebut agar selalu mempunyai `value` yang Anda berikan. Umumnya, kamu akan mengendalikan sebuah area teks dengan mendeklarasikan sebuah [variabel *state*:](/reference/react/useState)
 
 ```js {2,6,7}
 function NewPost() {
@@ -340,10 +340,10 @@ textarea { display: block; margin-top: 5px; margin-bottom: 10px; }
 
 ### Area teks saya tidak memperbarui ketika Saya mengetiknya {/*my-text-area-doesnt-update-when-i-type-into-it*/}
 
-Jika Anda *render* sebuah area teks dengan `value` tetapi tanpa `onChange`, Anda akan melihat sebuah *error* di konsol:
+Jika Anda me-*render* sebuah area teks dengan `value` tetapi tanpa `onChange`, Anda akan melihat sebuah *error* di konsol:
 
 ```js
-// 🔴 Bug: area teks terkendali tanpa handler onChange
+// 🔴 Bug: area teks terkendali (*controlled*) tanpa handler onChange
 <textarea value={something} />
 ```
 
@@ -356,14 +356,14 @@ Anda memberikan sebuah *prop* `value` ke sebuah *field* formulir tanpa sebuah *h
 Seperti yang disarankan pada pesan *error* berikut, jika Anda hanya ingin [menentukan nilai *awal*,](#providing-an-initial-value-for-a-text-area) berikan `defaultValue` sebagai gantinya:
 
 ```js
-// ✅ Good: area teks tidak terkendali dengan sebuah nilai awal
+// ✅ Good: area teks tidak terkendali (*uncontrolled*) dengan sebuah nilai awal
 <textarea defaultValue={something} />
 ```
 
 Jika Anda ingin [mengendalikan area teks ini dengan sebuah variabel *state*,](#controlling-a-text-area-with-a-state-variable) Tentukanlah sebuah *handler* `onChange`:
 
 ```js
-// ✅ Good: area teks terkendali dengan onChange
+// ✅ Good: area teks terkendali (*controlled*) dengan onChange
 <textarea value={something} onChange={e => setSomething(e.target.value)} />
 ```
 
@@ -404,7 +404,7 @@ Untuk memperbaiki kode Anda, perbarui secara sinkron ke `e.target.value`:
 
 ```js
 function handleChange(e) {
-  // ✅ Memperbarui sebuah input terkendali ke e.target.value secara sinkron
+  // ✅ Memperbarui sebuah input terkendali (*controlled*) ke e.target.value secara sinkron
   setFirstName(e.target.value);
 }
 ```
@@ -413,7 +413,7 @@ Jika ini tidak menyelesaikan masalah, ada kemungkinan area teks terhapus dan dit
 
 ---
 
-### Saya menerima sebuah error: "Sebuah komponen sedang mengubah input yang tidak terkendali menjadi terkendali" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
+### Saya menerima sebuah error: "Sebuah komponen sedang mengubah input yang tidak terkendali (*uncontrolled*) menjadi terkendali (*controlled*)" {/*im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled*/}
 
 
 Jika Anda memberikan sebuah `value` ke komponen, nilai tersebut harus tetap berupa string selama masa pakainya.

--- a/src/content/reference/react-dom/components/textarea.md
+++ b/src/content/reference/react-dom/components/textarea.md
@@ -69,11 +69,11 @@ Jika `<textarea>` Anda tidak terkontrol, Anda boleh memberikan `defaultValue` se
 
 #### Caveats {/*caveats*/}
 
-- Passing children like `<textarea>something</textarea>` is not allowed. [Use `defaultValue` for initial content.](#providing-an-initial-value-for-a-text-area)
-- If a text area receives a string `value` prop, it will be [treated as controlled.](#controlling-a-text-area-with-a-state-variable)
-- A text area can't be both controlled and uncontrolled at the same time.
-- A text area cannot switch between being controlled or uncontrolled over its lifetime.
-- Every controlled text area needs an `onChange` event handler that synchronously updates its backing value.
+- Memberikan <em>children</em> seperti `<textarea>something</textarea>` tidak diperbolehkan. [Gunakan `defaultValue` untuk konten awal.](#providing-an-initial-value-for-a-text-area)
+- Jika menerima sebuah <em>prop</em> `value` string, sebuah area teks akan [dianggap sebagai terkontrol.](#controlling-a-text-area-with-a-state-variable)
+- Sebuah area teks tidak dapat menjadi terkontrol dan tidak terkontrol secara bersamaan.
+- Sebuah area teks tidak dapat beralih menjadi terkontrol atau tidak terkontrol selama masa pakainya.
+- Setiap area teks terkontrol membutuhkan sebuah `onChange` <em>event handler</em> yang mengubah nilai pendukungnya secara sinkronis.
 
 ---
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Closes #433

Translate the textarea section into Bahasa

Reference page: https://id.react.dev/reference/react-dom/components/textarea
