### PR TITLE
docs(translation): use correct path for `content` folder

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -22,7 +22,7 @@ Untuk menjalankan situs id.react.dev secara lokal, ikuti langkah-langkah berikut
 4. Jalankan `yarn dev` untuk menjalankan *server* lokal.
 5. Buka alamat `localhost:3000` dalam peramban web Anda.
 
-Konten dari situs id.react.dev terdapat dalam folder `content`, dan disimpan dalam format Markdown. Buka proyek id.react.dev dalam program penyunting teks Anda, dan mulailah menyunting. Konten dalam situs lokal akan diperbarui secara otomatis.
+Konten dari situs id.react.dev terdapat dalam folder `src/content`, dan disimpan dalam format Markdown. Buka proyek id.react.dev dalam program penyunting teks Anda, dan mulailah menyunting. Konten dalam situs lokal akan diperbarui secara otomatis.
 
 ## Klaim halaman supaya tidak ada pekerjaan ganda
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Closes <!-- mention the issue that you're trying to close with this PR -->

## Description
Hallo, maaf untuk kontribusi yang sangat kecil.

Disini saya hanya menambahkan `src/content` mungkin untuk pemula seperti saya akan kebingungan mencari dimana leta lokasi `content` secara default.
