### PR TITLE
docs: change the link to style guide

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -7,8 +7,7 @@ Berikut adalah panduan-panduan dasar dalam penerjemahan situs react.dev ke Bahas
 Semua referensi mengenai penerjemahan terletak di [bagian Wiki](https://github.com/reactjs/id.react.dev/wiki) di repositori ini.
 
 - [Glosarium](https://github.com/reactjs/id.react.dev/wiki/Glosarium)
-- [Panduan Penulisan Universal](https://github.com/reactjs/id.react.dev/wiki/Panduan-Penulisan-Universal)
-- [Universal Style Guide (English)](https://github.com/reactjs/id.react.dev/wiki/Universal-Style-Guide)
+- [Panduan Penulisan Umum](https://github.com/reactjs/id.react.dev/wiki/Panduan-Penulisan-Umum)
 
 Apabila Anda ingin mendikusikan apapun mengenai proyek penerjemahan situs dokumentasi ini, termasuk umpan balik (*feedback*) mengenai Glosarium dan alur kerja (*workflow*), silakan ke [bagian Discussions](https://github.com/reactjs/id.react.dev/discussions).
 


### PR DESCRIPTION
This PR changes the references to the style guide, so only the Indonesian version is used. The English version is deprecated and will soon be deleted.

New link for Indonesian style guide is at: https://github.com/reactjs/id.react.dev/wiki/Panduan-Penulisan-Umum
