### PR TITLE
docs: translate Legacy React APIs

### DIFF
--- a/src/content/reference/react/legacy.md
+++ b/src/content/reference/react/legacy.md
@@ -14,7 +14,7 @@ API ini diekspor dari paket `react`, tapi tidak disarankan untuk digunakan dalam
 
 * [`Children`](/reference/react/Children) memungkinakn Anda memanipulasi dan mengubah JSX yang diterima sebagai *prop* `children`. [Lihat alternatif.](/reference/react/Children#alternatives)
 * [`cloneElement`](/reference/react/cloneElement) memungkinkan Anda membuat elemen React menggunakan elemen lain sebagai titik awal. [Lihat alternatif.](/reference/react/cloneElement#alternatives)
-* [`Component`](/reference/react/Component) memungkinkan Anda mendefinisikan komponen React sebagai *class* JavaScript. [Lihat alternatif.](/reference/react/Component#alternatives)
+* [`Component`](/reference/react/Component) memungkinkan Anda mendefinisikan komponen React sebagai kelas JavaScript. [Lihat alternatif.](/reference/react/Component#alternatives)
 * [`createElement`](/reference/react/createElement) memungkinkan Anda membuat elemen React. Biasanya Anda akan menggunakan JSX sebagai gantinya.
 * [`createRef`](/reference/react/createRef) membuat objek ref yang dapat berisi nilai arbiter. [Lihat alternatif.](/reference/react/createRef#alternatives)
 * [`isValidElement`](/reference/react/isValidElement) memeriksa apakah suatu nilai adalah elemen React. Biasanya digunakan dengan [`cloneElement`.](/reference/react/cloneElement)

--- a/src/content/reference/react/legacy.md
+++ b/src/content/reference/react/legacy.md
@@ -1,34 +1,33 @@
 ---
-title: "Legacy React APIs"
+title: "API React Lama"
 ---
 
 <Intro>
 
-These APIs are exported from the `react` package, but they are not recommended for use in newly written code. See the linked individual API pages for the suggested alternatives.
+API ini diekspor dari paket `react`, tapi tidak disarankan untuk digunakan dalam kode yang baru ditulis. Lihat halaman API individual tertaut untuk alternatif yang disarankan.
 
 </Intro>
 
 ---
 
-## Legacy APIs {/*legacy-apis*/}
+## API Lama {/*legacy-apis*/}
 
-* [`Children`](/reference/react/Children) lets you manipulate and transform the JSX received as the `children` prop. [See alternatives.](/reference/react/Children#alternatives)
-* [`cloneElement`](/reference/react/cloneElement) lets you create a React element using another element as a starting point. [See alternatives.](/reference/react/cloneElement#alternatives)
-* [`Component`](/reference/react/Component) lets you define a React component as a JavaScript class. [See alternatives.](/reference/react/Component#alternatives)
-* [`createElement`](/reference/react/createElement) lets you create a React element. Typically, you'll use JSX instead.
-* [`createRef`](/reference/react/createRef) creates a ref object which can contain arbitrary value. [See alternatives.](/reference/react/createRef#alternatives)
-* [`isValidElement`](/reference/react/isValidElement) checks whether a value is a React element. Typically used with [`cloneElement`.](/reference/react/cloneElement)
-* [`PureComponent`](/reference/react/PureComponent) is similar to [`Component`,](/reference/react/Component) but it skip re-renders with same props. [See alternatives.](/reference/react/PureComponent#alternatives)
-
+* [`Children`](/reference/react/Children) memungkinakn Anda memanipulasi dan mengubah JSX yang diterima sebagai *prop* `children`. [Lihat alternatif.](/reference/react/Children#alternatives)
+* [`cloneElement`](/reference/react/cloneElement) memungkinkan Anda membuat elemen React menggunakan elemen lain sebagai titik awal. [Lihat alternatif.](/reference/react/cloneElement#alternatives)
+* [`Component`](/reference/react/Component) memungkinkan Anda mendefinisikan komponen React sebagai *class* JavaScript. [Lihat alternatif.](/reference/react/Component#alternatives)
+* [`createElement`](/reference/react/createElement) memungkinkan Anda membuat elemen React. Biasanya Anda akan menggunakan JSX sebagai gantinya.
+* [`createRef`](/reference/react/createRef) membuat objek ref yang dapat berisi nilai arbiter. [Lihat alternatif.](/reference/react/createRef#alternatives)
+* [`isValidElement`](/reference/react/isValidElement) memeriksa apakah suatu nilai adalah elemen React. Biasanya digunakan dengan [`cloneElement`.](/reference/react/cloneElement)
+* [`PureComponent`](/reference/react/PureComponent) mirip dengan [`Component`,](/reference/react/Component) tetapi melewatkan render ulang dengan `props` yang sama. [Lihat alternatif.](/reference/react/PureComponent#alternatives)
 
 ---
 
-## Deprecated APIs {/*deprecated-apis*/}
+## API yang tidak digunakan lagi {/*deprecated-apis*/}
 
 <Deprecated>
 
-These APIs will be removed in a future major version of React.
+API ini akan dihapus di versi utama React yang akan datang.
 
 </Deprecated>
 
-* [`createFactory`](/reference/react/createFactory) lets you create a function that produces React elements of a certain type.
+* [`createFactory`](/reference/react/createFactory) memungkinkan Anda membuat fungsi yang menghasilkan elemen React dari tipe tertentu.

--- a/src/content/reference/react/legacy.md
+++ b/src/content/reference/react/legacy.md
@@ -12,7 +12,7 @@ API ini diekspor dari paket `react`, tapi tidak disarankan untuk digunakan dalam
 
 ## API Lama {/*legacy-apis*/}
 
-* [`Children`](/reference/react/Children) memungkinakn Anda memanipulasi dan mengubah JSX yang diterima sebagai *prop* `children`. [Lihat alternatif.](/reference/react/Children#alternatives)
+* [`Children`](/reference/react/Children) memungkinkan Anda memanipulasi dan mengubah JSX yang diterima sebagai *prop* `children`. [Lihat alternatif.](/reference/react/Children#alternatives)
 * [`cloneElement`](/reference/react/cloneElement) memungkinkan Anda membuat elemen React menggunakan elemen lain sebagai titik awal. [Lihat alternatif.](/reference/react/cloneElement#alternatives)
 * [`Component`](/reference/react/Component) memungkinkan Anda mendefinisikan komponen React sebagai kelas JavaScript. [Lihat alternatif.](/reference/react/Component#alternatives)
 * [`createElement`](/reference/react/createElement) memungkinkan Anda membuat elemen React. Biasanya Anda akan menggunakan JSX sebagai gantinya.
@@ -26,7 +26,7 @@ API ini diekspor dari paket `react`, tapi tidak disarankan untuk digunakan dalam
 
 <Deprecated>
 
-API ini akan dihapus di versi utama React yang akan datang.
+API-API ini akan dihapus di versi mayor React yang akan datang.
 
 </Deprecated>
 


### PR DESCRIPTION
Closes #545

## Description

Translate the Legacy React APIs page.
Page URL:  https://id.react.dev/reference/react/legacy
