### PR TITLE
docs: translate `preinitModule`

### DIFF
--- a/src/content/reference/react-dom/preinitModule.md
+++ b/src/content/reference/react-dom/preinitModule.md
@@ -4,13 +4,13 @@ title: preinitModule
 
 <Note>
 
-[React-based frameworks](/learn/start-a-new-react-project) frequently handle resource loading for you, so you might not have to call this API yourself. Consult your framework's documentation for details.
+[Framework berbasis React](/learn/start-a-new-react-project) sering kali menangani pemuatan sumber daya untuk Anda, jadi Anda mungkin tidak perlu memanggil API ini sendiri. Lihat dokumentasi framework Anda untuk detailnya.
 
 </Note>
 
 <Intro>
 
-`preinitModule` lets you eagerly fetch and evaluate an ESM module.
+`preinitModule` memungkinkan Anda mengambil dan mengevaluasi modul ESM dengan mudah.
 
 ```js
 preinitModule("https://example.com/module.js", {as: "script"});
@@ -22,11 +22,11 @@ preinitModule("https://example.com/module.js", {as: "script"});
 
 ---
 
-## Reference {/*reference*/}
+## Referensi {/*reference*/}
 
 ### `preinitModule(href, options)` {/*preinitmodule*/}
 
-To preinit an ESM module, call the `preinitModule` function from `react-dom`.
+Untuk melakukan inisialisasi terhadap sebuah modul ESM, panggil fungsi `preinitModule` dari `react-dom`.
 
 ```js
 import { preinitModule } from 'react-dom';
@@ -38,36 +38,36 @@ function AppRoot() {
 
 ```
 
-[See more examples below.](#usage)
+[Lihat contoh lainnya di bawah ini.](#usage)
 
-The `preinitModule` function provides the browser with a hint that it should start downloading and executing the given module, which can save time. Modules that you `preinit` are executed when they finish downloading.
+Fungsi `preinitModule` memberikan petunjuk kepada browser bahwa untuk mulai mengunduh dan mengeksekusi modul yang diberikan, yang dapat menghemat waktu. Modul yang kamu `preinit` akan dieksekusi segera setelah selesai diunduh.
 
-#### Parameters {/*parameters*/}
+#### Parameter {/*parameters*/}
 
-* `href`: a string. The URL of the module you want to download and execute.
-* `options`: an object. It contains the following properties:
-  *  `as`: a required string. It must be `'script'`.
-  *  `crossOrigin`: a string. The [CORS policy](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) to use. Its possible values are `anonymous` and `use-credentials`.
-  *  `integrity`: a string. A cryptographic hash of the module, to [verify its authenticity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).
-  *  `nonce`: a string. A cryptographic [nonce to allow the module](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) when using a strict Content Security Policy. 
+* `href`: sebuah string. URL modul yang ingin Anda unduh dan jalankan.
+* `options`: sebuah objek. Ini berisi properti-properti berikut:
+  *  `as`: sebuah string yang wajib. Harus berupa `'script'`.
+  *  `crossOrigin`: sebuah string. [Kebijakan CORS](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) yang akan digunakan. Nilai yang dapat digunakan adalah `anonymous` dan `use-credentials`.
+  *  `integrity`: sebuah string. *Hash* kriptografi modul, untuk [memverifikasi keasliannya](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).
+  *  `nonce`: sebuah string. Sebuah [*nonce* kriptografi untuk mengizinkan modul](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) ketika menggunakan *Content Security Policy* yang ketat.
 
-#### Returns {/*returns*/}
+#### Kembalian {/*returns*/}
 
-`preinitModule` returns nothing.
+`preinitModule` tidak mengembalikan apa pun.
 
-#### Caveats {/*caveats*/}
+#### Peringatan {/*caveats*/}
 
-* Multiple calls to `preinitModule` with the same `href` have the same effect as a single call.
-* In the browser, you can call `preinitModule` in any situation: while rendering a component, in an Effect, in an event handler, and so on.
-* In server-side rendering or when rendering Server Components, `preinitModule` only has an effect if you call it while rendering a component or in an async context originating from rendering a component. Any other calls will be ignored.
+* Beberapa pemanggilan `preinitModule` dengan `href` memiliki efek yang sama dengan panggilan tunggal.
+* Di browser, Anda dapat memanggil `preinitModule` dalam situasi apa pun: saat me-*render* komponen, di *Effect*, di *event handler*, dan sebagainya.
+* Dalam rendering sisi server atau saat me-render Komponen Server, `preinitModule` hanya memiliki efek jika Anda memanggilnya saat me-render komponen atau dalam konteks asinkronisasi yang berasal dari rendering komponen. Pemanggilan lainnya akan diabaikan.
 
 ---
 
-## Usage {/*usage*/}
+## Penggunaan {/*usage*/}
 
-### Preloading when rendering {/*preloading-when-rendering*/}
+### Preloading awal saat me-render {/*preloading-when-rendering*/}
 
-Call `preinitModule` when rendering a component if you know that it or its children will use a specific module and you're OK with the module being evaluated and thereby taking effect immediately upon being downloaded.
+Panggil `preinitModule` saat me-*render* komponen jika Anda mengetahui bahwa komponen tersebut atau anak komponennya akan menggunakan modul tertentu dan Anda setuju modul tersebut langsung dievaluasi serta berlaku segera setelah selesai diunduh.
 
 ```js
 import { preinitModule } from 'react-dom';
@@ -78,11 +78,11 @@ function AppRoot() {
 }
 ```
 
-If you want the browser to download the module but not to execute it right away, use [`preloadModule`](/reference/react-dom/preloadModule) instead. If you want to preinit a script that isn't an ESM module, use [`preinit`](/reference/react-dom/preinit).
+Jika Anda ingin agar browser hanya mengunduh modul tanpa langsung mengeksekusinya, gunakan [`preloadModule`](/reference/react-dom/preloadModule). Jika Anda ingin melakukan preinit skrip yang bukan modul ESM, gunakan [`preinit`](/reference/react-dom/preinit).
 
-### Preloading in an event handler {/*preloading-in-an-event-handler*/}
+### Preloading pada event handler {/*preloading-in-an-event-handler*/}
 
-Call `preinitModule` in an event handler before transitioning to a page or state where the module will be needed. This gets the process started earlier than if you call it during the rendering of the new page or state.
+Panggil `preinitModule` dalam *event handler* sebelum bertransisi ke halaman atau state yang membutuhkan modul. Hal ini akan memulai proses lebih awal dibandingkan jika Anda memanggilnya saat merender halaman atau state baru.
 
 ```js
 import { preinitModule } from 'react-dom';


### PR DESCRIPTION
## Description

Translate the `preinitModule` page.
Page URL: https://id.react.dev/reference/react-dom/preinitModule