### PR TITLE
Fix typo: "ulanh" → "ulang" in state reset example

### DIFF
--- a/src/content/learn/you-might-not-need-an-effect.md
+++ b/src/content/learn/you-might-not-need-an-effect.md
@@ -163,7 +163,7 @@ Komponen `ProfilePage` ini menerima *prop* `userId`. Halaman tersebut berisi *in
 export default function ProfilePage({ userId }) {
   const [comment, setComment] = useState('');
 
-  // 🔴 Hindari: menyetel ulanh state setiap prop berubah di dalam Effect
+  // 🔴 Hindari: menyetel ulang state setiap prop berubah di dalam Effect
   useEffect(() => {
     setComment('');
   }, [userId]);


### PR DESCRIPTION
This PR fixes a minor typo in the translated documentation for React (Indonesian version).

### ✅ Fix
- Typo: `ulanh` → `ulang`
- Affected section: Example about resetting state with `useEffect` when props change.

### 📍 Why
Correct spelling improves readability and helps learners better understand the content, especially those new to React.

Translate the **Anda Mungkin Tidak Membutuhkan Effect** page.
Page URL: https://id.react.dev/learn/you-might-not-need-an-effect
