### PR TITLE
ci: point maintainer workflows at react/react

### DIFF
--- a/.github/workflows/discord_notify.yml
+++ b/.github/workflows/discord_notify.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   check_maintainer:
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: react/react/.github/workflows/shared_check_maintainer.yml@main
     permissions:
       # Used by check_maintainer
       contents: read

--- a/.github/workflows/label_core_team_prs.yml
+++ b/.github/workflows/label_core_team_prs.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check_maintainer:
-    uses: facebook/react/.github/workflows/shared_check_maintainer.yml@main
+    uses: react/react/.github/workflows/shared_check_maintainer.yml@main
     permissions:
       # Used by check_maintainer
       contents: read


### PR DESCRIPTION
The facebook/react repo was renamed to react/react. GitHub repository API redirects, but reusable workflows do not, so Label Core Team PRs and Discord Notify fail at parse time with zero jobs.

Update both workflow `uses:` lines to react/react/.github/workflows/shared_check_maintainer.yml@main.